### PR TITLE
Feature/163976247 change marker gene json payload name

### DIFF
--- a/src/main/java/uk/ac/ebi/atlas/markergenes/HighchartsHeatmapAdapter.java
+++ b/src/main/java/uk/ac/ebi/atlas/markergenes/HighchartsHeatmapAdapter.java
@@ -53,7 +53,7 @@ public class HighchartsHeatmapAdapter {
                     Map<String, Object> heatmapCell = new HashMap<>();
                     heatmapCell.put("x", markerGene.clusterId() - 1);
                     heatmapCell.put("y", geneIdIndices.get(markerGene.geneId()));
-                    heatmapCell.put("name", symbolsForGeneIds.getOrDefault(markerGene.geneId(), markerGene.geneId()));
+                    heatmapCell.put("geneName", symbolsForGeneIds.getOrDefault(markerGene.geneId(), markerGene.geneId()));
                     heatmapCell.put("value", markerGene.medianExpression());
                     heatmapCell.put("clusterIdWhereMarker", markerGene.clusterIdWhereMarker());
                     heatmapCell.put("pValue", markerGene.pValue());

--- a/src/test/java/uk/ac/ebi/atlas/markergenes/HighchartsHeatmapAdapterTest.java
+++ b/src/test/java/uk/ac/ebi/atlas/markergenes/HighchartsHeatmapAdapterTest.java
@@ -56,8 +56,8 @@ public class HighchartsHeatmapAdapterTest {
         List<Map<String, Object>> result = subject.getMarkerGeneHeatmapData(markerGenes);
         assertThat(result).hasSize(3);
 
-        assertThat(result).element(0).extracting("name").containsOnly(geneSymbol1);
-        assertThat(result).element(1).extracting("name").containsOnly(geneSymbol2);
-        assertThat(result).element(2).extracting("name").containsOnly(gene3);
+        assertThat(result).element(0).extracting("geneName").containsOnly(geneSymbol1);
+        assertThat(result).element(1).extracting("geneName").containsOnly(geneSymbol2);
+        assertThat(result).element(2).extracting("geneName").containsOnly(gene3);
     }
 }

--- a/src/test/java/uk/ac/ebi/atlas/markergenes/JsonMarkerGenesControllerWIT.java
+++ b/src/test/java/uk/ac/ebi/atlas/markergenes/JsonMarkerGenesControllerWIT.java
@@ -89,7 +89,7 @@ public class JsonMarkerGenesControllerWIT {
                 .andExpect(jsonPath("$[0].clusterIdWhereMarker", isA(Number.class)))
                 .andExpect(jsonPath("$[0].x", isA(Number.class)))
                 .andExpect(jsonPath("$[0].y", isA(Number.class)))
-                .andExpect(jsonPath("$[0].name", isA(String.class)))
+                .andExpect(jsonPath("$[0].geneName", isA(String.class)))
                 .andExpect(jsonPath("$[0].value", isA(Number.class)))
                 .andExpect(jsonPath("$[0].pValue", isA(Number.class)));
     }


### PR DESCRIPTION
Since Highcharts export module use the `name` as the x-axis categories which is contradictory with the cluster number, I rename the parameter as `geneName` correspondingly.