### PR TITLE
Add new endpoint for tsne metadata for tsne plot widget

### DIFF
--- a/src/main/java/uk/ac/ebi/atlas/experimentpage/ExperimentPageContentService.java
+++ b/src/main/java/uk/ac/ebi/atlas/experimentpage/ExperimentPageContentService.java
@@ -44,9 +44,7 @@ public class ExperimentPageContentService {
         tsnePlotSettingsService.getExpectedClusters(experimentAccession)
                 .ifPresent(value -> result.addProperty("selectedK", value));
 
-        JsonArray perplexityArray = new JsonArray();
-        tsnePlotSettingsService.getAvailablePerplexities(experimentAccession).forEach(perplexityArray::add);
-        result.add("perplexities", perplexityArray);
+        result.add("perplexities", getPerplexities(experimentAccession));
 
         result.add("metadata", getMetadata(experimentAccession));
 
@@ -60,8 +58,13 @@ public class ExperimentPageContentService {
         return result;
     }
 
-    public JsonArray getTsnePlotMetaData(String experimentAccession) {
-        return getMetadata(experimentAccession);
+    public JsonObject getTsnePlotMetaDataAndPerplexities(String experimentAccession) {
+        JsonObject result = new JsonObject();
+
+        result.add("perplexities", getPerplexities(experimentAccession));
+        result.add("metadata", getMetadata(experimentAccession));
+
+        return result;
     }
 
     public JsonObject getExperimentDesign(String experimentAccession,
@@ -153,5 +156,11 @@ public class ExperimentPageContentService {
                 .forEach(x -> metadataArray.add(GSON.toJsonTree(x)));
 
         return metadataArray;
+    }
+
+    private JsonArray getPerplexities(String experimentAccession) {
+        JsonArray perplexityArray = new JsonArray();
+        tsnePlotSettingsService.getAvailablePerplexities(experimentAccession).forEach(perplexityArray::add);
+        return perplexityArray;
     }
 }

--- a/src/main/java/uk/ac/ebi/atlas/experimentpage/ExperimentPageContentService.java
+++ b/src/main/java/uk/ac/ebi/atlas/experimentpage/ExperimentPageContentService.java
@@ -14,6 +14,7 @@ import uk.ac.ebi.atlas.utils.StringUtil;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static uk.ac.ebi.atlas.utils.GsonProvider.GSON;
 
@@ -47,14 +48,7 @@ public class ExperimentPageContentService {
         tsnePlotSettingsService.getAvailablePerplexities(experimentAccession).forEach(perplexityArray::add);
         result.add("perplexities", perplexityArray);
 
-        JsonArray metadataArray = new JsonArray();
-        cellMetadataService.getMetadataTypes(experimentAccession)
-                .stream()
-                .map(x -> ImmutableMap.of("value", x, "label", StringUtil.snakeCaseToDisplayName(x)))
-                .collect(Collectors.toSet())
-                .forEach(x -> metadataArray.add(GSON.toJsonTree(x)));
-
-        result.add("metadata", metadataArray);
+        result.add("metadata", getMetadata(experimentAccession));
 
         JsonArray units = new JsonArray();
         units.add("TPM");
@@ -64,6 +58,10 @@ public class ExperimentPageContentService {
         result.addProperty("suggesterEndpoint", "json/suggestions");
 
         return result;
+    }
+
+    public JsonArray getTsnePlotMetaData(String experimentAccession) {
+        return getMetadata(experimentAccession);
     }
 
     public JsonObject getExperimentDesign(String experimentAccession,
@@ -144,5 +142,16 @@ public class ExperimentPageContentService {
         section.add("files", files);
 
         return section;
+    }
+
+    private JsonArray getMetadata(String experimentAccession) {
+        JsonArray metadataArray = new JsonArray();
+        cellMetadataService.getMetadataTypes(experimentAccession)
+                .stream()
+                .map(x -> ImmutableMap.of("value", x, "label", StringUtil.snakeCaseToDisplayName(x)))
+                .collect(Collectors.toSet())
+                .forEach(x -> metadataArray.add(GSON.toJsonTree(x)));
+
+        return metadataArray;
     }
 }

--- a/src/main/java/uk/ac/ebi/atlas/experimentpage/JsonExperimentTSnePlotController.java
+++ b/src/main/java/uk/ac/ebi/atlas/experimentpage/JsonExperimentTSnePlotController.java
@@ -133,7 +133,7 @@ public class JsonExperimentTSnePlotController extends JsonExperimentController {
             produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
     public String getTSnePlotMetadata(
             @PathVariable String experimentAccession) {
-        return GSON.toJson(experimentPageContentService.getTsnePlotMetaData(experimentAccession));
+        return GSON.toJson(experimentPageContentService.getTsnePlotMetaDataAndPerplexities(experimentAccession));
     }
 
     private List<Map<String, Object>> modelForHighcharts(String seriesNamePrefix, Map<?, Set<TSnePoint>> points) {

--- a/src/main/java/uk/ac/ebi/atlas/experimentpage/JsonExperimentTSnePlotController.java
+++ b/src/main/java/uk/ac/ebi/atlas/experimentpage/JsonExperimentTSnePlotController.java
@@ -29,11 +29,13 @@ import static uk.ac.ebi.atlas.utils.GsonProvider.GSON;
 @RestController
 public class JsonExperimentTSnePlotController extends JsonExperimentController {
     private final TSnePlotService tSnePlotService;
+    private final ExperimentPageContentService experimentPageContentService;
 
     @Inject
-    public JsonExperimentTSnePlotController(ScxaExperimentTrader experimentTrader, TSnePlotService tSnePlotService) {
+    public JsonExperimentTSnePlotController(ScxaExperimentTrader experimentTrader, TSnePlotService tSnePlotService, ExperimentPageContentService experimentPageContentService) {
         super(experimentTrader);
         this.tSnePlotService = tSnePlotService;
+        this.experimentPageContentService = experimentPageContentService;
     }
 
     @RequestMapping(
@@ -123,6 +125,15 @@ public class JsonExperimentTSnePlotController extends JsonExperimentController {
         min.ifPresent(n -> model.put("min", n));
 
         return GSON.toJson(model);
+    }
+
+    @RequestMapping(
+            value = "json/experiments/{experimentAccession}/metadata",
+            method = RequestMethod.GET,
+            produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+    public String getTSnePlotMetadata(
+            @PathVariable String experimentAccession) {
+        return GSON.toJson(experimentPageContentService.getTsnePlotMetaData(experimentAccession));
     }
 
     private List<Map<String, Object>> modelForHighcharts(String seriesNamePrefix, Map<?, Set<TSnePoint>> points) {

--- a/src/test/java/uk/ac/ebi/atlas/experimentpage/JsonExperimentTSnePlotControllerWIT.java
+++ b/src/test/java/uk/ac/ebi/atlas/experimentpage/JsonExperimentTSnePlotControllerWIT.java
@@ -42,7 +42,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @ContextConfiguration(classes = TestConfig.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class JsonExperimentTSnePlotControllerWIT {
-    private static final String URL = "/json/experiments/{experimentAccession}/metadata";
+    private static final String EXPERIMENT_METADATA_ENDPOINT_URL = "/json/experiments/{experimentAccession}/metadata";
 
     @Inject
     private DataSource dataSource;
@@ -205,10 +205,19 @@ class JsonExperimentTSnePlotControllerWIT {
                 .andExpect(jsonPath("$.series", hasSize(1)));
     }
 
+    @Test
+    void emptyJsonForExperimentWithNoMetadata() throws Exception {
+        mockMvc.perform(get(EXPERIMENT_METADATA_ENDPOINT_URL, "E-GEOD-99058"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8))
+                .andExpect(jsonPath("$.[0].label").doesNotExist())
+                .andExpect(jsonPath("$.[*]", hasSize(0)));
+    }
+
     @ParameterizedTest
     @MethodSource("experimentsWithMetadataProvider")
     void validJsonWithValidExperimentAccession(String experimentAccession) throws Exception {
-        mockMvc.perform(get(URL, experimentAccession))
+        mockMvc.perform(get(EXPERIMENT_METADATA_ENDPOINT_URL, experimentAccession))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8))
                 .andExpect(jsonPath("$.[0].label").exists())


### PR DESCRIPTION
Added new endpoint for tsne plot metadata to be used by tsne plot widget. Endpoint returns array of metadata.
Added new test cases for new metadata endpoint to check following:
- Valid Json for invalid metadata
- Valid Json for valid metada
- Valid Json for valid ExperimentAccession

Link to green build:

http://bar:8085/browse/ATLAS-ATLASWEBSCGRCI3-1