### PR TITLE
Bugfix #166430782 – Show build info in `json/build` endpoint

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -125,16 +125,21 @@ processResources {
 
     filesMatching(['*.properties', '*.xml']) {
         expand(
+                projectBuildDirectory: buildDir,
+                dataFilesLocation: dataFilesLocation,
                 jdbcUrl: jdbcUrl,
                 jdbcUsername: jdbcUsername,
                 jdbcPassword: jdbcPassword,
-                dataFilesLocation: dataFilesLocation,
-                projectBuildDirectory: buildDir,
-                testLogs: testLogs,
                 zkHost: zkHost,
                 zkPort: zkPort,
                 solrHost: solrHost,
-                solrPort: solrPort
+                solrPort: solrPort,
+                testLogs: testLogs,
+                buildNumber: '${buildNumber}',
+                buildBranch: '${buildBranch}',
+                buildRevision: '${buildRevision}',
+                catalinaBase: '${catalina.base}',
+                tomcatHostname: '${tomcat.hostname}'
         )
     }
 }
@@ -147,16 +152,21 @@ processTestResources {
 
     filesMatching(['*.properties', '*.xml']) {
         expand(
+                projectBuildDirectory: buildDir,
+                dataFilesLocation: dataFilesLocation,
                 jdbcUrl: jdbcUrl,
                 jdbcUsername: jdbcUsername,
                 jdbcPassword: jdbcPassword,
-                dataFilesLocation: dataFilesLocation,
-                projectBuildDirectory: buildDir,
-                testLogs: testLogs,
                 zkHost: zkHost,
                 zkPort: zkPort,
                 solrHost: solrHost,
-                solrPort: solrPort
+                solrPort: solrPort,
+                testLogs: testLogs,
+                buildNumber: '${buildNumber}',
+                buildBranch: '${buildBranch}',
+                buildRevision: '${buildRevision}',
+                catalinaBase: '${catalina.base}',
+                tomcatHostname: '${tomcat.hostname}'
         )
     }
 }

--- a/src/main/java/uk/ac/ebi/atlas/monitoring/JsonBuildVersionController.java
+++ b/src/main/java/uk/ac/ebi/atlas/monitoring/JsonBuildVersionController.java
@@ -9,41 +9,28 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
 import uk.ac.ebi.atlas.controllers.JsonExceptionHandlingController;
 
-import javax.inject.Inject;
-
 import static uk.ac.ebi.atlas.utils.GsonProvider.GSON;
 
 @RestController
 @PropertySource("classpath:configuration.properties")
 public class JsonBuildVersionController extends JsonExceptionHandlingController {
+    private final ImmutableMap<String, String> buildVersion;
 
-    private String buildNumber;
-    private String buildBranch;
-    private String buildCommitId;
-    private String tomcatHostname;
-
-    @Inject
-    public JsonBuildVersionController(@Value("${buildNumber}") String buildNumber,
-                                      @Value("${buildBranch}") String buildBranch,
-                                      @Value("${buildCommitId}") String buildCommitId,
-                                      @Value("${tomcatHostname}") String tomcatHostname) {
-        this.buildNumber = buildNumber;
-        this.buildBranch = buildBranch;
-        this.buildCommitId = buildCommitId;
-        this.tomcatHostname = tomcatHostname;
+    public JsonBuildVersionController(@Value("${build.number}") String buildNumber,
+                                      @Value("${build.branch}") String buildBranch,
+                                      @Value("${build.commitId}") String buildCommitId,
+                                      @Value("${build.tomcatHostname}") String tomcatHostname) {
+        buildVersion = ImmutableMap.of(
+                "bambooBuildVersion", buildNumber,
+                "gitBranch", buildBranch,
+                "gitCommitID", buildCommitId,
+                "tomcatHostname", tomcatHostname);
     }
 
-    @RequestMapping(
-            value = "/json/build",
-            method = RequestMethod.GET,
-            produces = MediaType.APPLICATION_JSON_UTF8_VALUE
-    )
+    @RequestMapping(value = "/json/build",
+                    method = RequestMethod.GET,
+                    produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
     public String getBuildInfo() {
-        return GSON.toJson(
-                ImmutableMap.of(
-                        "bambooBuildVersion", buildNumber,
-                        "gitBranch", buildBranch,
-                        "gitCommitID", buildCommitId,
-                        "tomcatHostname", tomcatHostname));
+        return GSON.toJson(buildVersion);
     }
 }

--- a/src/main/resources/configuration.properties
+++ b/src/main/resources/configuration.properties
@@ -1,2 +1,7 @@
 data.files.location = ${dataFilesLocation}
 experiment.files.location = ${dataFilesLocation}/scxa
+
+build.number = ${buildNumber}
+build.branch = ${buildBranch}
+build.commitId = ${buildRevision}
+build.tomcatHostname = ${tomcatHostname}

--- a/src/test/java/uk/ac/ebi/atlas/monitoring/HealthCheckControllerWIT.java
+++ b/src/test/java/uk/ac/ebi/atlas/monitoring/HealthCheckControllerWIT.java
@@ -24,7 +24,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WebAppConfiguration
 @ContextConfiguration(classes = TestConfig.class)
 class HealthCheckControllerWIT {
-
     @Autowired
     private WebApplicationContext wac;
 


### PR DESCRIPTION
In the previous monolithic repository of EA and SCEA we added an endpoint to display some fields to know which Bamboo build no. and which branch/commit was deployed in testing, production, fallback and public servers.

After the change to Gradle we can’t pass that properties directly to the build (if Gradle can do it I don’t know how), so I’ve added them to `configuration.properties` and then they get replaced with the variable expansion in the resource processing task.

You can change that it works by passing the following VM options to Tomcat:
```-DbuildNumber=dev -DbuildBranch=dev -DbuildRevision=dev -Dtomcat.hostname=local```

With this change we have now full feature-parity with our old repo. :smiley: 

This also uses the changes from https://github.com/ebi-gene-expression-group/atlas-web-core/pull/11.