### PR TITLE
Add sdrf technology type parser into sc experiment

### DIFF
--- a/src/main/java/uk/ac/ebi/atlas/trader/ScxaExperimentRepository.java
+++ b/src/main/java/uk/ac/ebi/atlas/trader/ScxaExperimentRepository.java
@@ -56,6 +56,6 @@ public class ScxaExperimentRepository implements ExperimentRepository {
                 experimentDto,
                 experimentDesignParser.parse(experimentDto.getExperimentAccession()),
                 idfParser.parse(experimentDto.getExperimentAccession()),
-                sdrfParser.parse(experimentDto.getExperimentAccession()));
+                sdrfParser.parseSingleCellTechnologyType(experimentDto.getExperimentAccession()));
     }
 }

--- a/src/main/java/uk/ac/ebi/atlas/trader/ScxaExperimentRepository.java
+++ b/src/main/java/uk/ac/ebi/atlas/trader/ScxaExperimentRepository.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Repository;
 import uk.ac.ebi.atlas.controllers.ResourceNotFoundException;
 import uk.ac.ebi.atlas.experimentimport.ExperimentCrudDao;
 import uk.ac.ebi.atlas.experimentimport.idf.IdfParser;
+import uk.ac.ebi.atlas.experimentimport.sdrf.SdrfParser;
 import uk.ac.ebi.atlas.model.experiment.Experiment;
 import uk.ac.ebi.atlas.model.experiment.ExperimentType;
 import uk.ac.ebi.atlas.trader.factory.SingleCellBaselineExperimentFactory;
@@ -18,16 +19,19 @@ public class ScxaExperimentRepository implements ExperimentRepository {
     private final ExperimentCrudDao experimentCrudDao;
     private final ExperimentDesignParser experimentDesignParser;
     private final IdfParser idfParser;
+    private final SdrfParser sdrfParser;
     private final SingleCellBaselineExperimentFactory singleCellBaselineExperimentFactory;
 
     public ScxaExperimentRepository(ExperimentCrudDao experimentCrudDao,
                                     ExperimentDesignParser experimentDesignParser,
                                     IdfParser idfParser,
-                                    SingleCellBaselineExperimentFactory singleCellBaselineExperimentFactory) {
+                                    SingleCellBaselineExperimentFactory singleCellBaselineExperimentFactory,
+                                    SdrfParser sdrfParser) {
         this.experimentCrudDao = experimentCrudDao;
         this.experimentDesignParser = experimentDesignParser;
         this.idfParser = idfParser;
         this.singleCellBaselineExperimentFactory = singleCellBaselineExperimentFactory;
+        this.sdrfParser = sdrfParser;
     }
 
     @Override
@@ -51,6 +55,7 @@ public class ScxaExperimentRepository implements ExperimentRepository {
         return singleCellBaselineExperimentFactory.create(
                 experimentDto,
                 experimentDesignParser.parse(experimentDto.getExperimentAccession()),
-                idfParser.parse(experimentDto.getExperimentAccession()));
+                idfParser.parse(experimentDto.getExperimentAccession()),
+                sdrfParser.parse(experimentDto.getExperimentAccession()));
     }
 }

--- a/src/test/java/uk/ac/ebi/atlas/trader/ScxaExperimentRepositoryTest.java
+++ b/src/test/java/uk/ac/ebi/atlas/trader/ScxaExperimentRepositoryTest.java
@@ -10,6 +10,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import uk.ac.ebi.atlas.experimentimport.ExperimentCrudDao;
 import uk.ac.ebi.atlas.experimentimport.ExperimentDto;
 import uk.ac.ebi.atlas.experimentimport.idf.IdfParser;
+import uk.ac.ebi.atlas.experimentimport.sdrf.SdrfParser;
 import uk.ac.ebi.atlas.model.experiment.ExperimentType;
 import uk.ac.ebi.atlas.trader.factory.SingleCellBaselineExperimentFactory;
 
@@ -40,6 +41,9 @@ class ScxaExperimentRepositoryTest {
     private IdfParser idfParserMock;
 
     @Mock
+    private SdrfParser sdrfParserMock;
+
+    @Mock
     private SingleCellBaselineExperimentFactory experimentFactoryMock;
 
     private ScxaExperimentRepository subject;
@@ -51,7 +55,8 @@ class ScxaExperimentRepositoryTest {
                         experimentCrudDaoMock,
                         experimentDesignParserMock,
                         idfParserMock,
-                        experimentFactoryMock);
+                        experimentFactoryMock,
+                        sdrfParserMock);
     }
 
     @ParameterizedTest


### PR DESCRIPTION
Company with the [sdrf core branch](https://github.com/ebi-gene-expression-group/atlas-web-core/pull/20). Add sdrf parser into experiment repository, i.e. to add technology type field into `sc/json/experiments` response.