### PR TITLE
Add param to experiments json endpoint

### DIFF
--- a/src/main/java/uk/ac/ebi/atlas/experiments/ExperimentsListController.java
+++ b/src/main/java/uk/ac/ebi/atlas/experiments/ExperimentsListController.java
@@ -5,7 +5,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import static com.google.common.base.Strings.isNullOrEmpty;
 import static uk.ac.ebi.atlas.utils.GsonProvider.GSON;
 
 @RestController
@@ -19,9 +18,8 @@ public class ExperimentsListController {
 
     //Used by experiments table page
     @GetMapping(value = "/json/experiments",
-            produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
-    public String getExperimentsList(@RequestParam(defaultValue = "") String organism_part) {
-        return isNullOrEmpty(organism_part) ? GSON.toJson(experimentInfoListService.getExperimentsJson()) :
-                GSON.toJson(experimentInfoListService.getExperimentsJson(CHARACTERISTIC_NAME, organism_part));
+                produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+    public String getExperimentsList(@RequestParam(defaultValue = "") String organismPart) {
+        return GSON.toJson(experimentInfoListService.getExperimentsJson(CHARACTERISTIC_NAME, organismPart));
     }
 }

--- a/src/main/java/uk/ac/ebi/atlas/experiments/ExperimentsListController.java
+++ b/src/main/java/uk/ac/ebi/atlas/experiments/ExperimentsListController.java
@@ -2,12 +2,15 @@ package uk.ac.ebi.atlas.experiments;
 
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import static com.google.common.base.Strings.isNullOrEmpty;
 import static uk.ac.ebi.atlas.utils.GsonProvider.GSON;
 
 @RestController
 public class ExperimentsListController {
+    private final static String CHARACTERISTIC_NAME = "organism_part";
     private final ExperimentInfoListService experimentInfoListService;
 
     public ExperimentsListController(ExperimentInfoListService experimentInfoListService) {
@@ -16,8 +19,9 @@ public class ExperimentsListController {
 
     //Used by experiments table page
     @GetMapping(value = "/json/experiments",
-                produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
-    public String getExperimentsList() {
-        return GSON.toJson(experimentInfoListService.getExperimentsJson());
+            produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+    public String getExperimentsList(@RequestParam(defaultValue = "") String organism_part) {
+        return isNullOrEmpty(organism_part) ? GSON.toJson(experimentInfoListService.getExperimentsJson()) :
+                GSON.toJson(experimentInfoListService.getExperimentsJson(CHARACTERISTIC_NAME, organism_part));
     }
 }

--- a/src/test/java/uk/ac/ebi/atlas/experiments/ExperimentsListControllerWIT.java
+++ b/src/test/java/uk/ac/ebi/atlas/experiments/ExperimentsListControllerWIT.java
@@ -1,0 +1,89 @@
+package uk.ac.ebi.atlas.experiments;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.datasource.init.ResourceDatabasePopulator;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import uk.ac.ebi.atlas.configuration.TestConfig;
+
+import javax.inject.Inject;
+import javax.sql.DataSource;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(SpringExtension.class)
+@WebAppConfiguration
+@ContextConfiguration(classes = TestConfig.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class ExperimentsListControllerWIT {
+
+    @Inject
+    private DataSource dataSource;
+
+    @Autowired
+    private WebApplicationContext wac;
+    private MockMvc mockMvc;
+
+    private static final String ENDPOINT_URL = "/json/experiments";
+
+    @BeforeAll
+    void populateDatabaseTables() {
+        ResourceDatabasePopulator populator = new ResourceDatabasePopulator();
+        populator.addScripts(new ClassPathResource("fixtures/experiment-fixture.sql"));
+        populator.execute(dataSource);
+    }
+
+    @AfterAll
+    void cleanDatabaseTables() {
+        ResourceDatabasePopulator populator = new ResourceDatabasePopulator();
+        populator.addScripts(new ClassPathResource("fixtures/experiment-delete.sql"));
+        populator.execute(dataSource);
+    }
+
+    @BeforeEach
+    void setUp() {
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(this.wac).build();
+    }
+
+    @Test
+    void hasExperimentsListWithoutAnyParameter() throws Exception {
+        mockMvc.perform(get(ENDPOINT_URL))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8))
+                .andExpect(jsonPath("$.aaData").isArray())
+                .andExpect(jsonPath("$.aaData").isNotEmpty());
+    }
+
+    @Test
+    void hasEmptyExperimentsListWithInvalidCharacteristicValueParameter() throws Exception {
+        mockMvc.perform(get(ENDPOINT_URL + "?organismPart=foo"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8))
+                .andExpect(jsonPath("$.aaData").isArray())
+                .andExpect(jsonPath("$.aaData").isEmpty());
+    }
+
+    @Test
+    void hasExperimentsListWithInvalidParameters() throws Exception {
+        mockMvc.perform(get(ENDPOINT_URL+ "?foo=bar"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8))
+                .andExpect(jsonPath("$.aaData").isArray())
+                .andExpect(jsonPath("$.aaData").isNotEmpty());
+    }
+}


### PR DESCRIPTION
For HCA landing page we need to show anatomograms and intended functionality we want to achieve is when a user clicks on an organism part e.g. lung then all the experiments which contain lung as an organism part are shown. Details regarding the implementation details are in following pivotal ticket:

https://www.pivotaltracker.com/story/show/169594225