### PR TITLE
Add HCA landing page

### DIFF
--- a/src/main/webapp/resources/html/hca-landing-page.html
+++ b/src/main/webapp/resources/html/hca-landing-page.html
@@ -1,0 +1,13 @@
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.2.1/iframeResizer.min.js"></script>
+
+<div class="row column">
+    <iframe id="hca-landing-page-iframe" class="row" src="https://ebi-gene-expression-group.github.io/hca-landing-page/html/hca-landing-page.html"
+            style="width: 1px; min-width: 100%; border: none; display: block; overflow: hidden;">
+    </iframe>
+</div>
+
+<script>
+    document.addEventListener("DOMContentLoaded", function(event) {
+        iFrameResize({log:true}, '#hca-landing-page-iframe');
+    });
+</script>


### PR DESCRIPTION
I have created a new landing page for HCA i.e. `hca-landing-page.html` in `html` directory. Currently, the page is accessible through a URL i.e. https://{host}/gxa/sc/hca-landing-page.html.