### PR TITLE
Bugfix #170673385 – Experiments with data providers return a 500 error

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/tiles/views/experiment-page/experiment-description.jsp
+++ b/src/main/webapp/WEB-INF/jsp/tiles/views/experiment-page/experiment-description.jsp
@@ -83,7 +83,7 @@
             <div id="dataProvider">Raw Data Provider:
                 <c:forEach var="dataProvider" items="${dataProviderURL}" varStatus="i">
                 <a class="thick-link" title="Experiment Data Provider"
-                   href="${dataProvider}">${dataProviderDescription.get(i.index)}</a>
+                   href="${dataProvider}">${dataProviderDescription.asList.get(i.index)}</a>
                 </c:forEach>
             </div>
             </c:if>


### PR DESCRIPTION
Convert set to list before accessing random elements.
Very dumb error due to lack of typing in JSP :cry:.