### PR TITLE
Bugfix #170789143 – HCA landing page links are broken

### DIFF
--- a/src/main/java/uk/ac/ebi/atlas/hcalandingpage/JsonHcaLandingPageController.java
+++ b/src/main/java/uk/ac/ebi/atlas/hcalandingpage/JsonHcaLandingPageController.java
@@ -11,7 +11,8 @@ import uk.ac.ebi.atlas.model.card.CardModelAdapter;
 import uk.ac.ebi.atlas.utils.GsonProvider;
 
 import static uk.ac.ebi.atlas.model.card.CardIconType.IMAGE;
-import static uk.ac.ebi.atlas.utils.UrlHelpers.*;
+import static uk.ac.ebi.atlas.utils.UrlHelpers.getCustomUrl;
+import static uk.ac.ebi.atlas.utils.UrlHelpers.getExperimentLink;
 
 @RestController
 public class JsonHcaLandingPageController extends JsonExceptionHandlingController {

--- a/src/main/java/uk/ac/ebi/atlas/hcalandingpage/JsonHcaLandingPageController.java
+++ b/src/main/java/uk/ac/ebi/atlas/hcalandingpage/JsonHcaLandingPageController.java
@@ -27,30 +27,38 @@ public class JsonHcaLandingPageController extends JsonExceptionHandlingControlle
             return ImmutableList.of(
                     CardModel.create(
                             IMAGE,
-                            getCustomUrl("/resources/images/logos/hca_cell_logo.png"),
+                            getCustomUrl("www.ebi.ac.uk", "/resources/images/logos/hca_cell_logo.png"),
                             ImmutableList.of(
                                     getExperimentLink(
+                                            "www.ebi.ac.uk",
                                             "Mouse cells – Small intestinal epithelium",
                                             "E-EHCA-2"),
                                     getExperimentLink(
+                                            "www.ebi.ac.uk",
                                             "Single cell transcriptome analysis of human pancreas",
                                             "E-GEOD-81547"),
                                     getExperimentLink(
+                                            "www.ebi.ac.uk",
                                             "Single-cell RNA-seq analysis of 1,732 cells throughout a 125-day differentiation protocol that converted H1 human embryonic stem cells to a variety of ventrally-derived cell types",
                                             "E-GEOD-93593"),
                                     getExperimentLink(
+                                            "www.ebi.ac.uk",
                                             "Single-cell RNA-seq analysis of human pancreas from healthy individuals and type 2 diabetes patients",
                                             "E-MTAB-5061"),
                                     getExperimentLink(
+                                            "www.ebi.ac.uk",
                                             "Single-cell transcriptome analysis of precursors of human CD4+ cytotoxic T lymphocytes",
                                             "E-GEOD-106540"),
                                     getExperimentLink(
+                                            "www.ebi.ac.uk",
                                             "Tabula Muris",
                                             "E-ENAD-15"),
                                     getExperimentLink(
+                                            "www.ebi.ac.uk",
                                             "Reconstructing the human first trimester fetal-maternal interface using single cell transcriptomics – 10x data",
                                             "E-MTAB-6701"),
                                     getExperimentLink(
+                                            "www.ebi.ac.uk",
                                             "Reconstructing the human first trimester fetal-maternal interface using single cell transcriptomics – Smartseq 2 data",
                                             "E-MTAB-6678"))));
     }


### PR DESCRIPTION
Companion PR of https://github.com/ebi-gene-expression-group/atlas-web-core/pull/33. Use the newly added methods in `UrlHelpers` in the HCA landing page controller.