### PR TITLE
Fix HCA metadata endpoint and cache for for hca metada solr query

### DIFF
--- a/src/main/java/uk/ac/ebi/atlas/configuration/CacheConfig.java
+++ b/src/main/java/uk/ac/ebi/atlas/configuration/CacheConfig.java
@@ -26,6 +26,8 @@ public class CacheConfig {
 
                 builder -> builder.name("jsonCellMetadata"),
                 builder -> builder.name("jsonTSnePlotWithClusters"),
-                builder -> builder.name("jsonTSnePlotWithMetadata"));
+                builder -> builder.name("jsonTSnePlotWithMetadata"),
+
+                builder -> builder.name("hcaMetadata"));
     }
 }

--- a/src/main/java/uk/ac/ebi/atlas/hcalandingpage/HcaMetadataDao.java
+++ b/src/main/java/uk/ac/ebi/atlas/hcalandingpage/HcaMetadataDao.java
@@ -3,6 +3,7 @@ package uk.ac.ebi.atlas.hcalandingpage;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import org.apache.solr.client.solrj.SolrQuery;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Component;
 import uk.ac.ebi.atlas.solr.cloud.SolrCloudCollectionProxyFactory;
 import uk.ac.ebi.atlas.solr.cloud.TupleStreamer;
@@ -70,13 +71,15 @@ innerJoin(
 function below is mimicking the behavior of the above query
 
 */
+    @Cacheable("hcaMetadata")
     public ImmutableSet<ArrayList<HashMap<String, String>>> fetchHumanExperimentAccessionsAndAssociatedOntologyIds() {
         var humanExperiments =
                 new SolrQueryBuilder<SingleCellAnalyticsCollectionProxy>()
                         .addQueryFieldByTerm(CHARACTERISTIC_NAME, ORGANISM)
                         .addQueryFieldByTerm(CHARACTERISTIC_VALUE, HOMO_SAPIENS)
                         .setFieldList(EXPERIMENT_ACCESSION)
-                        .sortBy(EXPERIMENT_ACCESSION, SolrQuery.ORDER.asc);
+                        .sortBy(EXPERIMENT_ACCESSION, SolrQuery.ORDER.asc)
+                        .setRows(10000000);
 
         var humanExperimentsSearchStream = new SearchStreamBuilder<>(singleCellAnalyticsCollectionProxy, humanExperiments);
         var uniqueHumanExperimentsStream = new UniqueStreamBuilder(humanExperimentsSearchStream, EXPERIMENT_ACCESSION.name());


### PR DESCRIPTION
As the result of one part of solr stream query was larger than the default rows we set for solr query so we were missing on some of the information. Also as this query is taking a while to return the response (on my local machine it is taking around a minute). So added a cache for this method as well.