### PR TITLE
Update row numbers for solr query

### DIFF
--- a/src/main/java/uk/ac/ebi/atlas/hcalandingpage/HcaHumanExperimentDao.java
+++ b/src/main/java/uk/ac/ebi/atlas/hcalandingpage/HcaHumanExperimentDao.java
@@ -36,7 +36,8 @@ public class HcaHumanExperimentDao {
         queryBuilder
                 .setNormalize(false)
                 .addQueryFieldByTerm(CHARACTERISTIC_NAME, characteristicName)
-                .setFieldList(EXPERIMENT_ACCESSION);
+                .setFieldList(EXPERIMENT_ACCESSION)
+                .setRows(10000000);
         if (isNotBlank(characteristicValue)) {
             queryBuilder
                     .addQueryFieldByTerm(ImmutableMap.of(


### PR DESCRIPTION
As we saw in [this HCA PR](https://github.com/ebi-gene-expression-group/atlas-web-single-cell/pull/91) the size of the result set of solr query was similar in case of this endpoint as well so increased the number of rows to get the correct result.