### PR TITLE
Bugfix #172654192 – Values of metadata t-SNE plot are truncated

### DIFF
--- a/src/main/java/uk/ac/ebi/atlas/experimentpage/metadata/CellMetadataDao.java
+++ b/src/main/java/uk/ac/ebi/atlas/experimentpage/metadata/CellMetadataDao.java
@@ -132,6 +132,7 @@ public class CellMetadataDao {
 
         var queryBuilder =
                 new SolrQueryBuilder<SingleCellAnalyticsCollectionProxy>()
+                        .setRows(1500000)
                         .addFilterFieldByTerm(EXPERIMENT_ACCESSION, experimentAccession)
                         .addQueryFieldByTerm(fields)
                         .setFieldList(ImmutableSet.of(CELL_ID, CHARACTERISTIC_VALUE, FACTOR_VALUE));

--- a/src/main/java/uk/ac/ebi/atlas/experimentpage/metadata/CellMetadataDao.java
+++ b/src/main/java/uk/ac/ebi/atlas/experimentpage/metadata/CellMetadataDao.java
@@ -42,6 +42,7 @@ public class CellMetadataDao {
 
     private final static String INFERRED_CELL_TYPE_SOLR_VALUE = "inferred_cell_type";
     private final static String SINGLE_CELL_IDENTIFIER_SOLR_VALUE = "single_cell_identifier";
+    private final static String METADATA_VALUE_TARGET_FIELD_NAME = "metadata_value";
 
     public CellMetadataDao(SolrCloudCollectionProxyFactory solrCloudCollectionProxyFactory,
                            IdfParser idfParser) {
@@ -129,9 +130,7 @@ public class CellMetadataDao {
     // Given a type of metadata and an experiment accession, this method retrieves the value of that metadata for the
     // cells in an experiment
     public ImmutableMap<String, String> getMetadataValues(String experimentAccession,
-                                                            String metadataType) {
-        var METADATA_VALUE_TARGET_FIELD_NAME = "metadata_value";
-
+                                                          String metadataType) {
         // Find matching characteristic name and factor name docs...
         var solrQueryBuilder =
                 new SolrQueryBuilder<SingleCellAnalyticsCollectionProxy>()

--- a/src/main/java/uk/ac/ebi/atlas/experimentpage/metadata/CellMetadataService.java
+++ b/src/main/java/uk/ac/ebi/atlas/experimentpage/metadata/CellMetadataService.java
@@ -4,15 +4,13 @@ import com.google.common.collect.ImmutableSet;
 import org.springframework.stereotype.Component;
 
 import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 
 @Component
 public class CellMetadataService {
-    private CellMetadataDao cellMetadataDao;
+    private final CellMetadataDao cellMetadataDao;
 
     public CellMetadataService(CellMetadataDao cellMetadataDao) {
         this.cellMetadataDao = cellMetadataDao;


### PR DESCRIPTION
We were mis-labelling cells as _Not available_ because the Solr query had a row limit and the resulting map was missing many cell IDs.

I tried first to use the JSON facet API using two facets, one for `facet_characteristic_name` and another for `facet_factor_name`, since the resulting data structure bucketing by metadata value seemed more natural. However the time penalty was higher than I expected and took well over 30 seconds in big experiments, making that approach not good. You can try it yourself:
```bash
curl http://wp-np2-85:8983/solr/scxa-analytics/query -d '
rows=0&
q=*:*&
fl=cell_id,factor_value,characteristic_value&
json.facet={
  cells: {
    refine: true,
    type: terms,
    field: cell_id,
    limit: -1,
    domain: { filter: "experiment_accession:E-HCAD-4" }
    facet: {
      characteristic: {
        mincount: 1,
        refine: true,
        type: terms,
        field: facet_characteristic_value,
        limit: -1,
        domain: { filter: "characteristic_name:inferred_cell_type" }
      },
      factor: {
        mincount: 1,
        refine: true,
        type: terms,
        field: facet_factor_value,
        limit: -1,
        domain: { filter: "factor_name:inferred_cell_type" }
      }
    }
  }
}
'
```
That’s the reason why there are substantial modifications to the `SolrJsonFacetBuilder`. In any case the resulting change is an improvement, so I left it there. 

Then I tried the streaming expression approach and found a way to use [the `/export` handler](https://lucene.apache.org/solr/guide/7_1/stream-source-reference.html#search-parameters), which is ideal for our use case. :smile: 