### PR TITLE
Only show metadataType with 2 or more values

### DIFF
--- a/src/main/java/uk/ac/ebi/atlas/experimentpage/metadata/CellMetadataService.java
+++ b/src/main/java/uk/ac/ebi/atlas/experimentpage/metadata/CellMetadataService.java
@@ -28,8 +28,8 @@ public class CellMetadataService {
                 characteristicTypes);
     }
 
-    public Map<String, String> getMetadataValuesForGivenType(String experimentAccession, String metedataType) {
-        return cellMetadataDao.getMetadataValues(experimentAccession, metedataType);
+    public Map<String, String> getMetadataValuesForGivenType(String experimentAccession, String metadataType) {
+        return cellMetadataDao.getMetadataValues(experimentAccession, metadataType);
     }
 
     /*

--- a/src/main/java/uk/ac/ebi/atlas/experimentpage/metadata/CellMetadataService.java
+++ b/src/main/java/uk/ac/ebi/atlas/experimentpage/metadata/CellMetadataService.java
@@ -28,6 +28,10 @@ public class CellMetadataService {
                 characteristicTypes);
     }
 
+    public Map<String, String> getMetadataValuesForGivenType(String experimentAccession, String metedataType) {
+        return cellMetadataDao.getMetadataValues(experimentAccession, metedataType);
+    }
+
     /*
      * Retrieves a list of metadata types of interest for the experiment. This includes all factors (excluding the
      * single cell identifier), curated attributes found in the IDF file, as well as the inferred cell type

--- a/src/main/java/uk/ac/ebi/atlas/experimentpage/tabs/ExperimentPageContentService.java
+++ b/src/main/java/uk/ac/ebi/atlas/experimentpage/tabs/ExperimentPageContentService.java
@@ -145,7 +145,7 @@ public class ExperimentPageContentService {
 
     public JsonArray getMetadata(String experimentAccession) {
         var metadataArray = new JsonArray();
-        var metadataTypes = cellMetadataService
+        cellMetadataService
                 .getMetadataTypes(experimentAccession)
                 .stream()
                 .filter(type -> cellMetadataService
@@ -154,13 +154,10 @@ public class ExperimentPageContentService {
                         .stream()
                         .distinct()
                         .count() >= 2)//we only need to show those metadata type which have more than 2 unique values
-                .collect(ImmutableSet.toImmutableSet());
-
-        metadataTypes
-                .stream()
                 .map(x -> ImmutableMap.of("value", x, "label", StringUtil.snakeCaseToDisplayName(x)))
                 .collect(Collectors.toSet())
-                .forEach(x -> metadataArray.add(GSON.toJsonTree(x)));
+                .forEach(metadata -> metadataArray.add(GSON.toJsonTree(metadata)));
+
         return metadataArray;
     }
 

--- a/src/main/java/uk/ac/ebi/atlas/experimentpage/tabs/ExperimentPageContentService.java
+++ b/src/main/java/uk/ac/ebi/atlas/experimentpage/tabs/ExperimentPageContentService.java
@@ -2,6 +2,7 @@ package uk.ac.ebi.atlas.experimentpage.tabs;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
@@ -144,7 +145,18 @@ public class ExperimentPageContentService {
 
     public JsonArray getMetadata(String experimentAccession) {
         var metadataArray = new JsonArray();
-        cellMetadataService.getMetadataTypes(experimentAccession)
+        var metadataTypes = cellMetadataService
+                .getMetadataTypes(experimentAccession)
+                .stream()
+                .filter(type -> cellMetadataService
+                        .getMetadataValuesForGivenType(experimentAccession, type)
+                        .values()
+                        .stream()
+                        .distinct()
+                        .count() >= 2)//we only need to show those metadata type which have more than 2 unique values
+                .collect(ImmutableSet.toImmutableSet());
+
+        metadataTypes
                 .stream()
                 .map(x -> ImmutableMap.of("value", x, "label", StringUtil.snakeCaseToDisplayName(x)))
                 .collect(Collectors.toSet())
@@ -164,7 +176,7 @@ public class ExperimentPageContentService {
 
         result.addProperty("url", url);
         result.addProperty("type", experimentFileType.getIconType().getName());
-        result.addProperty("description",  experimentFileType.getDescription());
+        result.addProperty("description", experimentFileType.getDescription());
         result.addProperty("isDownload", true);
 
         return result;
@@ -186,7 +198,7 @@ public class ExperimentPageContentService {
     }
 
     private JsonObject customContentTab(String tabType, String name, String onlyPropName, JsonElement value) {
-        var props =  new JsonObject();
+        var props = new JsonObject();
         props.add(onlyPropName, value);
         return customContentTab(tabType, name, props);
     }

--- a/src/test/java/uk/ac/ebi/atlas/experimentpage/TSnePlotSettingsServiceTest.java
+++ b/src/test/java/uk/ac/ebi/atlas/experimentpage/TSnePlotSettingsServiceTest.java
@@ -79,7 +79,7 @@ class TSnePlotSettingsServiceTest {
                 .thenReturn(
                         new IdfParserOutput(
                                 "Title",
-                                "",
+                                Collections.emptyList(),
                                 "Description",
                                 Collections.emptyList(),
                                 Integer.parseInt(IDF_PREFERRED_K),
@@ -99,7 +99,7 @@ class TSnePlotSettingsServiceTest {
                 .thenReturn(
                         new IdfParserOutput(
                                 "Title",
-                                "",
+                                Collections.emptyList(),
                                 "Description",
                                 Collections.emptyList(),
                                 Integer.parseInt(IDF_PREFERRED_K),
@@ -120,7 +120,7 @@ class TSnePlotSettingsServiceTest {
                 .thenReturn(
                         new IdfParserOutput(
                                 "Title",
-                                "",
+                                Collections.emptyList(),
                                 "Description",
                                 Collections.emptyList(),
                                 Integer.parseInt(IDF_PREFERRED_K),
@@ -138,7 +138,7 @@ class TSnePlotSettingsServiceTest {
                 .thenReturn(
                         new IdfParserOutput(
                                 "Title",
-                                "",
+                                Collections.emptyList(),
                                 "Description",
                                 Collections.emptyList(),
                                 Integer.parseInt(IDF_PREFERRED_K),
@@ -159,7 +159,7 @@ class TSnePlotSettingsServiceTest {
                 .thenReturn(
                         new IdfParserOutput(
                                 "Title",
-                                "",
+                                Collections.emptyList(),
                                 "Description",
                                 Collections.emptyList(),
                                 0,
@@ -180,7 +180,7 @@ class TSnePlotSettingsServiceTest {
                 .thenReturn(
                         new IdfParserOutput(
                                 "Title",
-                                "",
+                                Collections.emptyList(),
                                 "Description",
                                 Collections.emptyList(),
                                 0,

--- a/src/test/java/uk/ac/ebi/atlas/experimentpage/metadata/CellMetadataServiceIT.java
+++ b/src/test/java/uk/ac/ebi/atlas/experimentpage/metadata/CellMetadataServiceIT.java
@@ -34,6 +34,7 @@ class CellMetadataServiceIT {
     // Ideally we would retrieve a random experiment accession, but not all experiments have metadata of interest
     // (i.e factors, inferred cell types and additional attributes in the IDF)
     private static final String EXPERIMENT_WITHOUT_METADATA_ACCESSION = "E-GEOD-99058";
+    private static final String INFERRED_CELL_TYPE = "inferred_cell_type";
 
     @Inject
     private DataSource dataSource;
@@ -83,7 +84,15 @@ class CellMetadataServiceIT {
     void experimentWithMetadataReturnsMetadataTypes(String experimentAccession) {
         assertThat(subject.getMetadataTypes(experimentAccession))
                 .isNotEmpty()
-                .contains("inferred_cell_type");
+                .contains(INFERRED_CELL_TYPE);
+    }
+
+    @ParameterizedTest
+    @MethodSource("experimentsWithMetadataProvider")
+    void returnsMetadataValueForGivenMetadataType(String experimentAccession) {
+        //assuming all experiments have inferred_cell_types as there metadata
+        assertThat(subject.getMetadataValuesForGivenType(experimentAccession, INFERRED_CELL_TYPE))
+                .isNotEmpty();
     }
 
     @Test

--- a/src/test/java/uk/ac/ebi/atlas/experiments/ExperimentBuilder.java
+++ b/src/test/java/uk/ac/ebi/atlas/experiments/ExperimentBuilder.java
@@ -1,6 +1,7 @@
 package uk.ac.ebi.atlas.experiments;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import uk.ac.ebi.atlas.model.arraydesign.ArrayDesign;
 import uk.ac.ebi.atlas.model.experiment.Experiment;
@@ -38,7 +39,8 @@ public abstract class ExperimentBuilder<R extends ReportsGeneExpression, E exten
     List<String> technologyType = Arrays.asList(randomAlphabetic(6));
     ExperimentType experimentType = getRandomExperimentType();
     String experimentAccession = generateRandomExperimentAccession();
-    String secondaryExperimentAccession = RNG.nextBoolean() ? generateRandomPrideExperimentAccession() : "";
+    ImmutableSet<String> secondaryExperimentAccession = RNG.nextBoolean() ?
+            ImmutableSet.of(generateRandomPrideExperimentAccession()) : ImmutableSet.of("");
     String experimentDescription = randomAlphabetic(60);
     Date loadDate = new Date();
     Date lastUpdate = new Date();
@@ -272,6 +274,7 @@ public abstract class ExperimentBuilder<R extends ReportsGeneExpression, E exten
             return new SingleCellBaselineExperiment(
                     experimentType,
                     experimentAccession,
+                    secondaryExperimentAccession,
                     experimentDescription,
                     loadDate,
                     lastUpdate,


### PR DESCRIPTION
We don't want to show metadata types in tsne plot dropdowns which only have 1 value.