### PR TITLE
Bugfix #174786171 – Supplementary Information tab is broken

### DIFF
--- a/src/main/java/uk/ac/ebi/atlas/experimentpage/ExternallyAvailableContentController.java
+++ b/src/main/java/uk/ac/ebi/atlas/experimentpage/ExternallyAvailableContentController.java
@@ -3,10 +3,10 @@ package uk.ac.ebi.atlas.experimentpage;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import org.springframework.http.MediaType;
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 import uk.ac.ebi.atlas.model.download.ExternallyAvailableContent;
 
 import java.net.MalformedURLException;
@@ -17,7 +17,7 @@ import java.util.List;
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 import static uk.ac.ebi.atlas.utils.GsonProvider.GSON;
 
-@Controller
+@RestController
 public class ExternallyAvailableContentController {
     private final ExpressionAtlasContentService expressionAtlasContentService;
 
@@ -26,7 +26,7 @@ public class ExternallyAvailableContentController {
     }
 
     @GetMapping(value = "json/experiments/{experimentAccession}/resources/{contentType}",
-            produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+                produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
     public String list(@PathVariable String experimentAccession,
                        @PathVariable String contentType,
                        @RequestParam(value = "accessKey", defaultValue = "") String accessKey) {


### PR DESCRIPTION
There was an error in rendering because requests to URLs such as `http://localhost:8080/gxa/sc/json/experiments/E-GEOD-99058/resources/SUPPLEMENTARY_INFORMATION` returned a 500 error.

The request mapping method is returning a String which is interpreted as a Spring MVC view becuase the `@ResponseBody` annotation is missing (compare with bulk Expression Atlas). I replaced `@Controller` with `@RestController` to implicitly add `@ResponseBody`.