### PR TITLE
Chore – Containerise SCXA for development

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,144 @@
+# Single Cell Expression Atlas
+
+## Requirements
+- Docker v19+
+- Docker Compose v1.25+
+- 60 GB of available storage (experiment files, PostgreSQL and Solr backup snapshots and Docker volumes)
+
+Notice that PostgreSQL and Solr snapshots are [`bind` mounted](https://docs.docker.com/storage/bind-mounts/) in order
+to move data back and forth from the containers. Actual files managed by either Solr or PostgreSQL are kept in volumes
+which will be reused even if the containers are removed or brought down by Docker Compose. If you want to start afresh
+delete the old volume (e.g. for Postgres `docker volume rm scxa-pgdata`) and re-run the necessary step to return to the
+initial state.
+
+## Code
+Clone the repositories of both Atlas Web Core (common business logic for bulk Expression Atlas and Single Cell
+Expression Atlas) and Single Cell Expression Atlas proper:
+```bash
+git clone --recurse-submodules https://github.com/ebi-gene-expression-group/atlas-web-core.git && \
+git clone --recurse-submodules https://github.com/ebi-gene-expression-group/atlas-web-single-cell.git
+```
+
+## Data
+Choose a suitable location for the experiment files, database and Solr backup data. Set the path in the variable
+`ATLAS_DATA_PATH`.
+
+To download the data you can use `rsync` if you’re connected to the EBI network (over VPN or from campus): 
+```bash
+ATLAS_DATA_PATH=/path/to/sc/atlas/data 
+rsync -ravz ebi-cli:/nfs/ftp/pub/databases/microarray/data/atlas/test/scxa/* $ATLAS_DATA_PATH
+```
+
+Alternatively you can use `wget` and connect to EBI’s FTP server over HTTP:
+```bash
+wget -P $ATLAS_DATA_PATH -c --reject="index.html*" --recursive -np -nc -nH --cut-dirs=7 --random-wait --wait 1 -e robots=off http://ftp.ebi.ac.uk/pub/databases/microarray/data/atlas/test/scxa/
+```
+
+Notice that either way `ATLAS_DATA_PATH` will be created for you if the directory doesn’t exist.
+
+## Bring up the environment
+Besides `ATLAS_DATA_PATH` you need to set some variables for the Postgres container. Use the settings below and replace
+`ATLAS_DATA_PATH` value to the directory you set up in the first step.
+
+In the `atlas-web-single-cell/docker` directory run the following:
+```bash
+ATLAS_DATA_PATH=/path/to/sc/atlas/data \
+POSTGRES_HOST=scxa-postgres \
+POSTGRES_DB=gxpscxadev \
+POSTGRES_USER=atlasprd3 \
+POSTGRES_PASSWORD=atlasprd3 \
+docker-compose up
+```
+
+You can also set a Docker Compose *Run* configuration in IntelliJ IDEA with the environment variables from the command
+above if you find that more convenient.
+
+After bringing up the containers, you may want to inspect the logs to see that all services are running fine. The last
+log should come from Tomcat, and it should be something similar to:
+```
+scxa-tomcat    | 18-Dec-2020 13:40:58.907 INFO [main] org.apache.catalina.startup.Catalina.start Server startup in 6705 ms
+```
+
+Now let’s populate both the Postgres database and the SolrCloud collections.
+
+### Postgres
+Run the  following command to restore Postgres data from the provided `pg-dump.bin` file:
+```bash
+docker exec -it scxa-postgres bash -c 'pg_restore -d $POSTGRES_DB -h localhost -p 5432 -U $POSTGRES_USER --clean /var/backups/postgresql/pg-dump.bin'
+```
+
+You’ll see some errors due to the way `pg_dump` and `pg_restore` deal with partitioned tables (`scxa_analytics` in our
+case). This is normal; they can be safely ignored. 
+
+A few minutes later your Postgres database will be ready.
+
+### SolrCloud
+Use the provided `Dockerfile` to bootstrap SolrCloud:
+```bash
+docker build -t scxa-solrcloud-bootstrap .
+docker run -i --rm --network scxa scxa-solrcloud-bootstrap
+```
+
+You will see many warnings or errors in Solr’s responses. That’s alright and to be expected, since the scripts that
+create the config sets, collections and define the schemas will attempt first to remove them to start from a clean,
+known state; however Solr will reply with an error if the collections can’t be deleted.
+
+Again, this step will take a few minutes.
+
+## Tomcat
+Copy the Tomcat credentials file to the container. The `admin` role is used to access several admin endpoints in Single
+Cell Expression Atlas (e.g. `/admin/experiments/help`). Tomcat’s `conf` directory is persisted as a volume so that we
+need to do this only once:
+```bash
+docker cp tomcat-users.xml scxa-tomcat:/usr/local/tomcat/conf
+```
+
+Run the Gradle task `war` in the `atlas-web-single-cell` directory:
+```bash
+cd atlas-web-single-cell
+./gradlew war
+```
+
+You should now have the file `build/libs/gxa#sc.war` which by default Tomcat’s naming conventions will be served at
+`gxa/sc`. Point your browser at `http://localhost:8080/gxa/sc` and voilà!
+
+Every time you re-run the `war` task the web app will be automatically re-deployed by Tomcat.
+
+## Backing up your data
+Eventually you’ll add new experiments to your development instance of SCXA, or new, improved collections in Solr will
+replace the old ones. In such cases you’ll want to get a snapshot of the data to share with the team. Below there are
+instructions to do that.
+
+### PostgreSQL
+If at some point you wish to create a backup dump of the database run the command below:
+```bash
+docker exec -it scxa-postgres bash -c 'pg_dump -d $POSTGRES_DB -h localhost -p 5432 -U $POSTGRES_USER -f /var/lib/postgresql/scxa/pg-dump.bin -F c -n $POSTGRES_USER -t $POSTGRES_USER.* -T *flyway*'
+```
+
+### SolrCloud
+```bash
+for SOLR_COLLECTION in $SOLR_COLLECTIONS
+do
+  START_DATE_IN_SECS=`date +%s`
+  curl "http://localhost:8983/solr/${SOLR_COLLECTION}/replication?command=backup&location=/var/backups/solr&name=${SOLR_COLLECTION}"
+
+  # Pattern enclosed in (?<=) is zero-width look-behind and (?=) is zero-width look-ahead, we match everything in between
+  COMPLETED_DATE=`curl -s "http://localhost:8983/solr/${SOLR_COLLECTION}/replication?command=details" | grep -oP '(?<="snapshotCompletedAt",").*(?=")'`
+  COMPLETED_DATE_IN_SECS=`date +%s -d "${COMPLETED_DATE}"`
+
+  # We wait until snapshotCompletedAt is later than the date we took before issuing the backup operation
+  while [ ${COMPLETED_DATE_IN_SECS} -lt ${START_DATE_IN_SECS} ]
+  do
+    sleep 1s
+    COMPLETED_DATE=`curl -s "http://localhost:8983/solr/${SOLR_COLLECTION}/replication?command=details" | grep -oP '(?<="snapshotCompletedAt",").*(?=")'`
+    COMPLETED_DATE_IN_SECS=`date +%s -d "${COMPLETED_DATE}"`
+  done
+done
+```
+
+### Update test data
+Remember to update the file and any new experiments added to the `filesystem` directory by syncing your
+`ATLAS_DATA_PATH` with `/nfs/ftp/pub/databases/microarray/data/atlas/test/scxa`:
+```bash
+rsync -ravz $ATLAS_DATA_PATH/* ebi-cli:/nfs/ftp/pub/databases/microarray/data/atlas/test/scxa/
+```

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ known state; however Solr will reply with an error if the collections can’t be
 
 Again, this step will take a few minutes.
 
-## Tomcat
+### Tomcat
 Copy the Tomcat credentials file to the container. The `admin` role is used to access several admin endpoints in Single
 Cell Expression Atlas (e.g. `/admin/experiments/help`). Tomcat’s `conf` directory is persisted as a volume so that we
 need to do this only once:

--- a/build.gradle
+++ b/build.gradle
@@ -12,15 +12,8 @@ plugins {
 }
 
 war {
-    archiveName 'sc.war'
+    archiveName 'gxa#sc.war'
 }
-
-task explodedWar(type: Copy) {
-    into "$buildDir/exploded"
-    with war
-}
-
-war.dependsOn explodedWar
 
 group 'uk.ac.ebi.ge'
 version '11.0.0-SNAPSHOT'

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,111 @@
+version: '3.4'
+services:
+  #### SolrCloud
+
+  zoo1:
+    image: zookeeper:3.4.14
+    restart: always
+    hostname: zoo1
+    volumes:
+      - /home/alf/Projects/atlas/integration-test-data/solrcloud/scxa/zoo1/data:/data
+      - /home/alf/Projects/atlas/integration-test-data/solrcloud/scxa/zoo1/datalog:/datalog
+    environment:
+      ZOO_MY_ID: 1
+      ZOO_SERVERS: server.1=0.0.0.0:2888:3888 server.2=zoo2:2888:3888 server.3=zoo3:2888:3888
+
+  zoo2:
+    image: zookeeper:3.4.14
+    restart: always
+    hostname: zoo2
+    volumes:
+      - /home/alf/Projects/atlas/integration-test-data/solrcloud/scxa/zoo2/data:/data
+      - /home/alf/Projects/atlas/integration-test-data/solrcloud/scxa/zoo2/datalog:/datalog
+    environment:
+      ZOO_MY_ID: 2
+      ZOO_SERVERS: server.1=zoo1:2888:3888 server.2=0.0.0.0:2888:3888 server.3=zoo3:2888:3888
+
+  zoo3:
+    image: zookeeper:3.4.14
+    restart: always
+    hostname: zoo3
+    volumes:
+      - /home/alf/Projects/atlas/integration-test-data/solrcloud/scxa/zoo3/data:/data
+      - /home/alf/Projects/atlas/integration-test-data/solrcloud/scxa/zoo3/datalog:/datalog
+    environment:
+      ZOO_MY_ID: 3
+      ZOO_SERVERS: server.1=zoo1:2888:3888 server.2=zoo2:2888:3888 server.3=0.0.0.0:2888:3888
+
+  solr1:
+    image: solr:7.1
+    ports:
+      - "8983:8983"
+    volumes:
+      - /home/alf/Projects/atlas/integration-test-data/solrcloud/scxa/solr1:/var/solr
+    environment:
+      - SOLR_HOME=/var/solr
+      - SOLR_HEAP=2g
+      - SOLR_OPTS=-Denable.runtime.lib=true
+      - ZK_HOST=zoo1:2181,zoo2:2181,zoo3:2181
+    depends_on:
+      - zoo1
+      - zoo2
+      - zoo3
+
+  solr2:
+    image: solr:7.1.0
+    ports:
+      - "8984:8983"
+    volumes:
+      - /home/alf/Projects/atlas/integration-test-data/solrcloud/scxa/solr2:/var/solr
+    environment:
+      - SOLR_HOME=/var/solr
+      - SOLR_HEAP=2g
+      - SOLR_OPTS=-Denable.runtime.lib=true
+      - ZK_HOST=zoo1:2181,zoo2:2181,zoo3:2181
+    depends_on:
+      - zoo1
+      - zoo2
+      - zoo3
+
+  #### Database
+
+  postgres:
+    image: postgres:10-alpine
+    restart: always
+    environment:
+      PGDATA: /var/lib/postgresql/data/pgdata
+      POSTGRES_USER: atlasprd3
+      POSTGRES_PASSWORD: atlasprd3
+      POSTGRES_DB: gxpscxadev
+    ports:
+      - "5432:5432"
+    volumes:
+      - /home/alf/Projects/atlas/integration-test-data/postgres/scxa:/var/lib/postgresql/data/pgdata
+
+  flyway:
+    image: flyway/flyway
+    command: -url=jdbc:postgresql://postgres/gxpscxadev -schemas=atlasprd3 -user=atlasprd3 -password=atlasprd3 -connectRetries=60 migrate
+    volumes:
+      - ../atlas-web-core/src/test/resources/schemas/flyway/scxa/:/flyway/sql
+    depends_on:
+      - postgres
+
+  #### Web server and filesystem
+
+  tomcat:
+    image: tomcat:latest
+    environment:
+      JPDA_ADDRESS: "*:8000"
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./build/libs:/usr/local/tomcat/webapps
+      - /home/alf/Projects/atlas/integration-test-data/filesystem:/atlas-data
+      - scxa_tomcat_conf:/usr/local/tomcat/conf
+    depends_on:
+      - postgres
+      - solr1
+      - solr2
+
+volumes:
+  scxa_tomcat_conf:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,8 +9,8 @@ services:
       - scxa
     restart: always
     volumes:
-      - /home/alf/Projects/atlas/integration-test-data/solrcloud/scxa/zoo1/data:/data
-      - /home/alf/Projects/atlas/integration-test-data/solrcloud/scxa/zoo1/datalog:/datalog
+      - $ATLAS_DATA_PATH/solrcloud/scxa/zoo1/data:/data
+      - $ATLAS_DATA_PATH/solrcloud/scxa/zoo1/datalog:/datalog
     environment:
       ZOO_MY_ID: 1
       ZOO_SERVERS: server.1=0.0.0.0:2888:3888 server.2=scxa-zk-2:2888:3888 server.3=scxa-zk-3:2888:3888
@@ -22,8 +22,8 @@ services:
       - scxa
     restart: always
     volumes:
-      - /home/alf/Projects/atlas/integration-test-data/solrcloud/scxa/zoo2/data:/data
-      - /home/alf/Projects/atlas/integration-test-data/solrcloud/scxa/zoo2/datalog:/datalog
+      - $ATLAS_DATA_PATH/solrcloud/scxa/zoo2/data:/data
+      - $ATLAS_DATA_PATH/solrcloud/scxa/zoo2/datalog:/datalog
     environment:
       ZOO_MY_ID: 2
       ZOO_SERVERS: server.1=scxa-zk-1:2888:3888 server.2=0.0.0.0:2888:3888 server.3=scxa-zk-3:2888:3888
@@ -35,8 +35,8 @@ services:
       - scxa
     restart: always
     volumes:
-      - /home/alf/Projects/atlas/integration-test-data/solrcloud/scxa/zoo3/data:/data
-      - /home/alf/Projects/atlas/integration-test-data/solrcloud/scxa/zoo3/datalog:/datalog
+      - $ATLAS_DATA_PATH/solrcloud/scxa/zoo3/data:/data
+      - $ATLAS_DATA_PATH/solrcloud/scxa/zoo3/datalog:/datalog
     environment:
       ZOO_MY_ID: 3
       ZOO_SERVERS: server.1=scxa-zk-1:2888:3888 server.2=scxa-zk-2:2888:3888 server.3=0.0.0.0:2888:3888
@@ -49,7 +49,7 @@ services:
     ports:
       - "8983:8983"
     volumes:
-      - /home/alf/Projects/atlas/integration-test-data/solrcloud/scxa/solr1:/var/solr
+      - $ATLAS_DATA_PATH/solrcloud/scxa/solr1:/var/solr
     environment:
       - SOLR_HOME=/var/solr
       - SOLR_HEAP=2g
@@ -68,7 +68,7 @@ services:
     ports:
       - "8984:8983"
     volumes:
-      - /home/alf/Projects/atlas/integration-test-data/solrcloud/scxa/solr2:/var/solr
+      - $ATLAS_DATA_PATH/solrcloud/scxa/solr2:/var/solr
     environment:
       - SOLR_HOME=/var/solr
       - SOLR_HEAP=2g
@@ -88,18 +88,21 @@ services:
     restart: always
     command: -c max_wal_size=2GB
     environment:
-      PGDATA: /var/lib/postgresql/data/pgdata
-      POSTGRES_USER: atlasprd3
-      POSTGRES_PASSWORD: atlasprd3
-      POSTGRES_DB: gxpscxadev
+      PGDATA: /var/lib/postgresql/scxa/pgdata
+      POSTGRES_USER: $POSTGRES_USER
+      POSTGRES_PASSWORD: $POSTGRES_PASSWORD
+      POSTGRES_DB: $POSTGRES_DB
     ports:
       - "5432:5432"
     volumes:
-      - /home/alf/Projects/atlas/integration-test-data/postgres/scxa:/var/lib/postgresql/data/pgdata
+      - $ATLAS_DATA_PATH/postgresql/scxa:/var/lib/postgresql/scxa
 
   flyway:
     image: flyway/flyway
-    command: -url=jdbc:postgresql://postgres/gxpscxadev -schemas=atlasprd3 -user=atlasprd3 -password=atlasprd3 -connectRetries=60 migrate
+    container_name: scxa-flyway
+    networks:
+      - scxa
+    command: -url=jdbc:postgresql://$POSTGRES_HOST/$POSTGRES_DB -schemas=$POSTGRES_USER -user=$POSTGRES_USER -password=$POSTGRES_PASSWORD -connectRetries=60 migrate
     volumes:
       - ../atlas-web-core/src/test/resources/schemas/flyway/scxa/:/flyway/sql
     depends_on:
@@ -117,8 +120,8 @@ services:
       - "8080:8080"
     volumes:
       - ./build/libs:/usr/local/tomcat/webapps
-      - /home/alf/Projects/atlas/integration-test-data/filesystem:/atlas-data
-      - scxa_tomcat_conf:/usr/local/tomcat/conf
+      - $ATLAS_DATA_PATH/filesystem:/atlas-data
+      - tomcat-conf:/usr/local/tomcat/conf
     depends_on:
       - postgres
       - solrcloud-1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,42 +1,51 @@
-version: '3.4'
+version: "3.6"
+
 services:
   #### SolrCloud
-
-  zoo1:
+  zk-1:
     image: zookeeper:3.4.14
+    container_name: scxa-zk-1
+    networks:
+      - scxa
     restart: always
-    hostname: zoo1
     volumes:
       - /home/alf/Projects/atlas/integration-test-data/solrcloud/scxa/zoo1/data:/data
       - /home/alf/Projects/atlas/integration-test-data/solrcloud/scxa/zoo1/datalog:/datalog
     environment:
       ZOO_MY_ID: 1
-      ZOO_SERVERS: server.1=0.0.0.0:2888:3888 server.2=zoo2:2888:3888 server.3=zoo3:2888:3888
+      ZOO_SERVERS: server.1=0.0.0.0:2888:3888 server.2=scxa-zk-2:2888:3888 server.3=scxa-zk-3:2888:3888
 
-  zoo2:
+  zk-2:
     image: zookeeper:3.4.14
+    container_name: scxa-zk-2
+    networks:
+      - scxa
     restart: always
-    hostname: zoo2
     volumes:
       - /home/alf/Projects/atlas/integration-test-data/solrcloud/scxa/zoo2/data:/data
       - /home/alf/Projects/atlas/integration-test-data/solrcloud/scxa/zoo2/datalog:/datalog
     environment:
       ZOO_MY_ID: 2
-      ZOO_SERVERS: server.1=zoo1:2888:3888 server.2=0.0.0.0:2888:3888 server.3=zoo3:2888:3888
+      ZOO_SERVERS: server.1=scxa-zk-1:2888:3888 server.2=0.0.0.0:2888:3888 server.3=scxa-zk-3:2888:3888
 
-  zoo3:
+  zk-3:
     image: zookeeper:3.4.14
+    container_name: scxa-zk-3
+    networks:
+      - scxa
     restart: always
-    hostname: zoo3
     volumes:
       - /home/alf/Projects/atlas/integration-test-data/solrcloud/scxa/zoo3/data:/data
       - /home/alf/Projects/atlas/integration-test-data/solrcloud/scxa/zoo3/datalog:/datalog
     environment:
       ZOO_MY_ID: 3
-      ZOO_SERVERS: server.1=zoo1:2888:3888 server.2=zoo2:2888:3888 server.3=0.0.0.0:2888:3888
+      ZOO_SERVERS: server.1=scxa-zk-1:2888:3888 server.2=scxa-zk-2:2888:3888 server.3=0.0.0.0:2888:3888
 
-  solr1:
+  solrcloud-1:
     image: solr:7.1
+    container_name: scxa-solrcloud-1
+    networks:
+      - scxa
     ports:
       - "8983:8983"
     volumes:
@@ -45,14 +54,17 @@ services:
       - SOLR_HOME=/var/solr
       - SOLR_HEAP=2g
       - SOLR_OPTS=-Denable.runtime.lib=true
-      - ZK_HOST=zoo1:2181,zoo2:2181,zoo3:2181
+      - ZK_HOST=scxa-zk-1:2181,scxa-zk-2:2181,scxa-zk-3:2181
     depends_on:
-      - zoo1
-      - zoo2
-      - zoo3
+      - zk-1
+      - zk-2
+      - zk-3
 
-  solr2:
+  solrcloud-2:
     image: solr:7.1.0
+    container_name: scxa-solrcloud-2
+    networks:
+      - scxa
     ports:
       - "8984:8983"
     volumes:
@@ -61,17 +73,20 @@ services:
       - SOLR_HOME=/var/solr
       - SOLR_HEAP=2g
       - SOLR_OPTS=-Denable.runtime.lib=true
-      - ZK_HOST=zoo1:2181,zoo2:2181,zoo3:2181
+      - ZK_HOST=scxa-zk-1:2181,scxa-zk-2:2181,scxa-zk-3:2181
     depends_on:
-      - zoo1
-      - zoo2
-      - zoo3
+      - zk-1
+      - zk-2
+      - zk-3
 
   #### Database
-
   postgres:
     image: postgres:10-alpine
+    container_name: $POSTGRES_HOST
+    networks:
+      - scxa
     restart: always
+    command: -c max_wal_size=2GB
     environment:
       PGDATA: /var/lib/postgresql/data/pgdata
       POSTGRES_USER: atlasprd3
@@ -91,9 +106,11 @@ services:
       - postgres
 
   #### Web server and filesystem
-
   tomcat:
-    image: tomcat:latest
+    image: tomcat:8-jdk11
+    container_name: scxa-tomcat
+    networks:
+      - scxa
     environment:
       JPDA_ADDRESS: "*:8000"
     ports:
@@ -104,8 +121,13 @@ services:
       - scxa_tomcat_conf:/usr/local/tomcat/conf
     depends_on:
       - postgres
-      - solr1
-      - solr2
+      - solrcloud-1
+      - solrcloud-2
 
 volumes:
-  scxa_tomcat_conf:
+  tomcat-conf:
+    name: scxa-tomcat-conf
+
+networks:
+  scxa:
+    name: scxa

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,16 @@
+FROM alpine:3.12
+
+RUN apk --no-cache add bash curl git grep
+
+RUN git clone https://github.com/ebi-gene-expression-group/index-scxa.git \
+    && git clone https://github.com/ebi-gene-expression-group/index-gxa.git
+
+COPY scxa-solrcloud-bootstrap-entrypoint.sh /entrypoint.sh
+
+# Collection .system is populated with BioSolr’s JAR blob when creating the scxa-analytics collection
+ENV SOLR_COLLECTIONS="scxa-analytics-v3 scxa-analytics-v4 scxa-analytics-v5 scxa-gene2experiment-v1 bioentities-v1"
+ENV SOLR_HOSTS="scxa-solrcloud-1:8983 scxa-solrcloud-2:8983"
+ENV SOLR_HOST="scxa-solrcloud-1:8983"
+ENV SOLR_NUM_SHARDS=2
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -9,8 +9,8 @@ services:
       - scxa
     restart: always
     volumes:
-      - $ATLAS_DATA_PATH/solrcloud/scxa/zoo1/data:/data
-      - $ATLAS_DATA_PATH/solrcloud/scxa/zoo1/datalog:/datalog
+      - zk-1-data:/data
+      - zk-1-datalog:/datalog
     environment:
       ZOO_MY_ID: 1
       ZOO_SERVERS: server.1=0.0.0.0:2888:3888 server.2=scxa-zk-2:2888:3888 server.3=scxa-zk-3:2888:3888
@@ -22,8 +22,8 @@ services:
       - scxa
     restart: always
     volumes:
-      - $ATLAS_DATA_PATH/solrcloud/scxa/zoo2/data:/data
-      - $ATLAS_DATA_PATH/solrcloud/scxa/zoo2/datalog:/datalog
+      - zk-2-data:/data
+      - zk-2-datalog:/datalog
     environment:
       ZOO_MY_ID: 2
       ZOO_SERVERS: server.1=scxa-zk-1:2888:3888 server.2=0.0.0.0:2888:3888 server.3=scxa-zk-3:2888:3888
@@ -35,8 +35,8 @@ services:
       - scxa
     restart: always
     volumes:
-      - $ATLAS_DATA_PATH/solrcloud/scxa/zoo3/data:/data
-      - $ATLAS_DATA_PATH/solrcloud/scxa/zoo3/datalog:/datalog
+      - zk-3-data:/data
+      - zk-3-datalog:/datalog
     environment:
       ZOO_MY_ID: 3
       ZOO_SERVERS: server.1=scxa-zk-1:2888:3888 server.2=scxa-zk-2:2888:3888 server.3=0.0.0.0:2888:3888
@@ -49,9 +49,9 @@ services:
     ports:
       - "8983:8983"
     volumes:
-      - $ATLAS_DATA_PATH/solrcloud/scxa/solr1:/var/solr
+      - solrcloud-1-data:/opt/solr/server/solr
+      - $ATLAS_DATA_PATH/solrcloud/solr1:/var/backups/solr
     environment:
-      - SOLR_HOME=/var/solr
       - SOLR_HEAP=2g
       - SOLR_OPTS=-Denable.runtime.lib=true
       - ZK_HOST=scxa-zk-1:2181,scxa-zk-2:2181,scxa-zk-3:2181
@@ -68,9 +68,9 @@ services:
     ports:
       - "8984:8983"
     volumes:
-      - $ATLAS_DATA_PATH/solrcloud/scxa/solr2:/var/solr
+      - solrcloud-2-data:/opt/solr/server/solr
+      - $ATLAS_DATA_PATH/solrcloud/solr2:/var/backups/solr
     environment:
-      - SOLR_HOME=/var/solr
       - SOLR_HEAP=2g
       - SOLR_OPTS=-Denable.runtime.lib=true
       - ZK_HOST=scxa-zk-1:2181,scxa-zk-2:2181,scxa-zk-3:2181
@@ -79,7 +79,7 @@ services:
       - zk-2
       - zk-3
 
-  #### Database
+  #### PostgreSQL database
   postgres:
     image: postgres:10-alpine
     container_name: $POSTGRES_HOST
@@ -88,14 +88,14 @@ services:
     restart: always
     command: -c max_wal_size=2GB
     environment:
-      PGDATA: /var/lib/postgresql/scxa/pgdata
       POSTGRES_USER: $POSTGRES_USER
       POSTGRES_PASSWORD: $POSTGRES_PASSWORD
       POSTGRES_DB: $POSTGRES_DB
     ports:
       - "5432:5432"
     volumes:
-      - $ATLAS_DATA_PATH/postgresql/scxa:/var/lib/postgresql/scxa
+      - pgdata:/var/lib/postgresql/data
+      - $ATLAS_DATA_PATH/postgresql:/var/backups/postgresql
 
   flyway:
     image: flyway/flyway
@@ -104,13 +104,13 @@ services:
       - scxa
     command: -url=jdbc:postgresql://$POSTGRES_HOST/$POSTGRES_DB -schemas=$POSTGRES_USER -user=$POSTGRES_USER -password=$POSTGRES_PASSWORD -connectRetries=60 migrate
     volumes:
-      - ../atlas-web-core/src/test/resources/schemas/flyway/scxa/:/flyway/sql
+      - ../../atlas-web-core/src/test/resources/schemas/flyway/scxa/:/flyway/sql
     depends_on:
       - postgres
 
   #### Web server and filesystem
   tomcat:
-    image: tomcat:8-jdk11
+    image: tomcat:9-jdk11
     container_name: scxa-tomcat
     networks:
       - scxa
@@ -119,7 +119,7 @@ services:
     ports:
       - "8080:8080"
     volumes:
-      - ./build/libs:/usr/local/tomcat/webapps
+      - ../build/libs:/usr/local/tomcat/webapps
       - $ATLAS_DATA_PATH/filesystem:/atlas-data
       - tomcat-conf:/usr/local/tomcat/conf
     depends_on:
@@ -128,6 +128,24 @@ services:
       - solrcloud-2
 
 volumes:
+  zk-1-data:
+    name: scxa-zk-1-data
+  zk-1-datalog:
+    name: scxa-zk-1-datalog
+  zk-2-data:
+    name: scxa-zk-2-data
+  zk-2-datalog:
+    name: scxa-zk-2-datalog
+  zk-3-data:
+    name: scxa-zk-3-data
+  zk-3-datalog:
+    name: scxa-zk-3-datalog
+  solrcloud-1-data:
+    name: scxa-solrcloud-1-data
+  solrcloud-2-data:
+    name: scxa-solrcloud-2-data
+  pgdata:
+    name: scxa-pgdata
   tomcat-conf:
     name: scxa-tomcat-conf
 

--- a/docker/scxa-solrcloud-bootstrap-entrypoint.sh
+++ b/docker/scxa-solrcloud-bootstrap-entrypoint.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+/index-gxa/bin/create-bioentities-collection.sh
+/index-gxa/bin/create-bioentities-schema.sh
+
+/index-scxa/bin/create-scxa-gene2experiment-config-set.sh
+/index-scxa/bin/create-scxa-gene2experiment-collection.sh
+/index-scxa/bin/create-scxa-gene2experiment-schema.sh
+
+cd /index-scxa
+git checkout 0.5.0
+/index-scxa/bin/create-scxa-analytics-config-set.sh
+/index-scxa/bin/create-scxa-analytics-collection.sh
+/index-scxa/bin/create-scxa-analytics-biosolr-lib.sh
+/index-scxa/bin/create-scxa-analytics-schema.sh
+
+cd /index-scxa
+git checkout 0.4.0
+/index-scxa/bin/create-scxa-analytics-config-set.sh
+/index-scxa/bin/create-scxa-analytics-collection.sh
+# We only want the most recent version of BioSolr
+# /index-scxa/bin/create-scxa-analytics-biosolr-lib.sh
+/index-scxa/bin/create-scxa-analytics-schema.sh
+
+cd /index-scxa
+git checkout 0.3.0
+/index-scxa/bin/create-scxa-analytics-config-set.sh
+/index-scxa/bin/create-scxa-analytics-collection.sh
+# We only want the most recent version of BioSolr
+# /index-scxa/bin/create-scxa-analytics-biosolr-lib.sh
+/index-scxa/bin/create-scxa-analytics-schema.sh
+
+# Restore all collections
+# Env variables come from Dockerfile
+for SOLR_HOST in $SOLR_HOSTS
+do
+  for SOLR_COLLECTION in $SOLR_COLLECTIONS
+  do
+    curl "http://${SOLR_HOST}/solr/${SOLR_COLLECTION}/replication?command=restore&location=/var/backups/solr&name=${SOLR_COLLECTION}"
+
+    # Pattern enclosed in (?<=) is zero-width look-behind and (?=) is zero-width look-ahead, we match everything in between
+    STATUS=`curl -s "http://${SOLR_HOST}/solr/${SOLR_COLLECTION}/replication?command=restorestatus" | grep -oP '(?<="status":").*(?=")'`
+
+    # We wait until "status" field is "success"
+    while [ "${STATUS}" != "success" ]
+    do
+      sleep 1s
+      STATUS=`curl -s "http://${SOLR_HOST}/solr/${SOLR_COLLECTION}/replication?command=restorestatus" | grep -oP '(?<="status":").*(?=")'`
+    done
+  done
+done

--- a/docker/tomcat-users.xml
+++ b/docker/tomcat-users.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<tomcat-users xmlns="http://tomcat.apache.org/xml"
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:schemaLocation="http://tomcat.apache.org/xml tomcat-users.xsd"
+              version="1.0">
+<!--
+  NOTE:  By default, no user is included in the "manager-gui" role required
+  to operate the "/manager/html" web application.  If you wish to use this app,
+  you must define such a user - the username and password are arbitrary. It is
+  strongly recommended that you do NOT use one of the users in the commented out
+  section below since they are intended for use with the examples web
+  application.
+-->
+<!--
+  NOTE:  The sample user and role entries below are intended for use with the
+  examples web application. They are wrapped in a comment and thus are ignored
+  when reading this file. If you wish to configure these users for use with the
+  examples web application, do not forget to remove the <!.. ..> that surrounds
+  them. You will also need to set the passwords to something appropriate.
+-->
+<!--
+  <role rolename="tomcat"/>
+  <role rolename="role1"/>
+  <user username="tomcat" password="<must-be-changed>" roles="tomcat"/>
+  <user username="both" password="<must-be-changed>" roles="tomcat,role1"/>
+  <user username="role1" password="<must-be-changed>" roles="role1"/>
+-->
+
+  <!-- Roles for Tomcat Manager -->
+  <role rolename="tomcat"/>
+  <role rolename="manager"/>
+  <role rolename="manager-gui"/>
+  <user username="tomcat" password="tomcat" roles="tomcat,manager,manager-gui"/>
+
+  <!-- Role for Single Cell Expression Atlas -->
+  <role rolename="admin"/>
+  <user username="scxa" password="scxa" roles="admin"/>
+</tomcat-users>

--- a/src/main/resources/configuration.properties
+++ b/src/main/resources/configuration.properties
@@ -1,4 +1,4 @@
-data.files.location = ${dataFilesLocation}
+data.files.location = /atlas-data
 experiment.files.location = ${dataFilesLocation}/scxa
 
 build.number = ${buildNumber}


### PR DESCRIPTION
Docker Compose files and scripts to easily bring up a Single Cell Expression Atlas instance with all necessary services, plus documentation on how to populate Postgres and SolrCloud with test data sets.