### PR TITLE
Optimise /json/experiments endpoint

### DIFF
--- a/src/main/java/uk/ac/ebi/atlas/configuration/CacheConfig.java
+++ b/src/main/java/uk/ac/ebi/atlas/configuration/CacheConfig.java
@@ -23,6 +23,7 @@ public class CacheConfig {
                 builder -> builder.name("experimentCollections").permitNullValues(true),
                 builder -> builder.name("experiment2Collections"),
 
+                builder -> builder.name("jsonExperimentsList"),
                 builder -> builder.name("jsonExperimentMetadata"),
                 builder -> builder.name("jsonExperimentPageTabs"),
                 builder -> builder.name("cellCounts"),

--- a/src/main/java/uk/ac/ebi/atlas/experimentimport/ScxaExperimentCrud.java
+++ b/src/main/java/uk/ac/ebi/atlas/experimentimport/ScxaExperimentCrud.java
@@ -44,7 +44,8 @@ public class ScxaExperimentCrud extends ExperimentCrud {
             @CacheEvict(cacheNames = "minimumMarkerProbability", key = "#experimentAccession"),
             @CacheEvict(cacheNames = "jsonCellMetadata", allEntries = true),
             @CacheEvict(cacheNames = "jsonTSnePlotWithClusters", allEntries = true),
-            @CacheEvict(cacheNames = "jsonTSnePlotWithMetadata", allEntries = true) })
+            @CacheEvict(cacheNames = "jsonTSnePlotWithMetadata", allEntries = true),
+            @CacheEvict(cacheNames = "jsonExperimentsList", allEntries = true) })
     public UUID createExperiment(String experimentAccession, boolean isPrivate) {
         var condensedSdrfParserOutput =
                 condensedSdrfParser.parse(experimentAccession, SINGLE_CELL_RNASEQ_MRNA_BASELINE);
@@ -80,7 +81,8 @@ public class ScxaExperimentCrud extends ExperimentCrud {
             @CacheEvict(cacheNames = "expectedClusters", key = "#experimentAccession"),
             @CacheEvict(cacheNames = "minimumMarkerProbability", key = "#experimentAccession"),
             @CacheEvict(cacheNames = "jsonCellMetadata", allEntries = true),
-            @CacheEvict(cacheNames = "jsonTSnePlotWithMetadata", allEntries = true) })
+            @CacheEvict(cacheNames = "jsonTSnePlotWithMetadata", allEntries = true),
+            @CacheEvict(cacheNames = "jsonExperimentsList", allEntries = true) })
     public void updateExperimentDesign(String experimentAccession) {
         var experimentDto =
                 readExperiment(experimentAccession)
@@ -107,7 +109,8 @@ public class ScxaExperimentCrud extends ExperimentCrud {
             @CacheEvict(cacheNames = "jsonCellMetadata", allEntries = true),
             @CacheEvict(cacheNames = "jsonTSnePlotWithClusters", allEntries = true),
             @CacheEvict(cacheNames = "jsonTSnePlotWithMetadata", allEntries = true),
-            @CacheEvict(cacheNames = "experiment2Collections", key = "#experimentAccession") })
+            @CacheEvict(cacheNames = "experiment2Collections", key = "#experimentAccession"),
+            @CacheEvict(cacheNames = "jsonExperimentsList", allEntries = true) })
     public void deleteExperiment(String experimentAccession) {
         super.deleteExperiment(experimentAccession);
     }
@@ -125,7 +128,8 @@ public class ScxaExperimentCrud extends ExperimentCrud {
             @CacheEvict(cacheNames = "minimumMarkerProbability", key = "#experimentAccession"),
             @CacheEvict(cacheNames = "jsonCellMetadata", allEntries = true),
             @CacheEvict(cacheNames = "jsonTSnePlotWithClusters", allEntries = true),
-            @CacheEvict(cacheNames = "jsonTSnePlotWithMetadata", allEntries = true) })
+            @CacheEvict(cacheNames = "jsonTSnePlotWithMetadata", allEntries = true),
+            @CacheEvict(cacheNames = "jsonExperimentsList", allEntries = true) })
     public void updateExperimentPrivate(String experimentAccession, boolean isPrivate) {
         super.updateExperimentPrivate(experimentAccession, isPrivate);
     }

--- a/src/main/java/uk/ac/ebi/atlas/experiments/ExperimentsListController.java
+++ b/src/main/java/uk/ac/ebi/atlas/experiments/ExperimentsListController.java
@@ -1,6 +1,7 @@
 package uk.ac.ebi.atlas.experiments;
 
 import com.google.common.collect.ImmutableMap;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -18,6 +19,7 @@ public class ExperimentsListController {
     //Used by experiments table page
     @GetMapping(value = "/json/experiments",
             produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+    @Cacheable("jsonExperimentsList")
     public String getExperimentsList() {
         return GSON.toJson(
                 ImmutableMap.of(


### PR DESCRIPTION
Mitch reported that /json/experiments endpoint was taking ~4 secs to return the experiment list. Upon investigation of the code, it was found that the results were not being cached. I added a new cache and also evicted it at the proper places in the experiment CRUD to keep the results consistent.