### PR TITLE
Hide Anatomogram with incomplete data

### DIFF
--- a/src/main/java/uk/ac/ebi/atlas/experimentpage/markergenes/MarkerGeneService.java
+++ b/src/main/java/uk/ac/ebi/atlas/experimentpage/markergenes/MarkerGeneService.java
@@ -16,35 +16,35 @@ public class MarkerGeneService {
         this.cellTypeSearchDao = cellTypeSearchDao;
     }
 
-	/**
-	 * Get ImmutableList of marker genes objects for an experiment of that organism part.
-	 *
-	 * @param organismPart
-	 * @param experimentAccession
-	 * @return ImmutableList of CellTypeMarkerGene Objects
-	 */
-	public ImmutableList<MarkerGene> getCellTypeMarkerGeneProfile(String experimentAccession, String organismPart) {
+    /**
+     * Get ImmutableList of marker genes objects for an experiment of that organism part.
+     *
+     * @param organismPart
+     * @param experimentAccession
+     * @return ImmutableList of CellTypeMarkerGene Objects
+     */
+    public ImmutableList<MarkerGene> getCellTypeMarkerGeneProfile(String experimentAccession, String organismPart) {
 
-		var ontologyLabelsCellTypeValues = cellTypeSearchDao.getInferredCellTypeOntologyLabels(experimentAccession, organismPart);
+        var ontologyLabelsCellTypeValues = cellTypeSearchDao.getInferredCellTypeOntologyLabels(experimentAccession, organismPart);
 
-		var cellTypeMarkerGenes = ontologyLabelsCellTypeValues.isEmpty() ?
-				markerGenesDao.getCellTypeMarkerGenes(experimentAccession,
-						cellTypeSearchDao.getInferredCellTypeAuthorsLabels(experimentAccession, organismPart)) :
-				markerGenesDao.getCellTypeMarkerGenes(experimentAccession, ontologyLabelsCellTypeValues);
+        var cellTypeMarkerGenes = ontologyLabelsCellTypeValues.isEmpty() ?
+                markerGenesDao.getCellTypeMarkerGenes(experimentAccession,
+                        cellTypeSearchDao.getInferredCellTypeAuthorsLabels(experimentAccession, organismPart)) :
+                markerGenesDao.getCellTypeMarkerGenes(experimentAccession, ontologyLabelsCellTypeValues);
 
-		return cellTypeMarkerGenes.stream()
-				.filter(markerGene -> !markerGene.cellGroupValue().equalsIgnoreCase("Not available"))
-				.filter(markerGene -> !markerGene.cellGroupValueWhereMarker().equalsIgnoreCase("Not available"))
-				.collect(toImmutableList());
-	}
+        return cellTypeMarkerGenes.stream()
+                .filter(markerGene -> !markerGene.cellGroupValue().equalsIgnoreCase("Not available"))
+                .filter(markerGene -> !markerGene.cellGroupValueWhereMarker().equalsIgnoreCase("Not available"))
+                .collect(toImmutableList());
+    }
 
-	/**
-	 * @param experimentAccession - Id of the experiment
-	 * @param k                   - no of clusters
-	 * @return Map<String, ImmutableSet < MarkerGene>> of cluster MarkerGenes
-	 * Objects as a value
-	 */
-	public ImmutableList<MarkerGene> getMarkerGenesPerCluster(String experimentAccession, String k) {
-		return ImmutableList.copyOf(markerGenesDao.getMarkerGenesWithAveragesPerCluster(experimentAccession, k));
-	}
+    /**
+     * @param experimentAccession - Id of the experiment
+     * @param k                   - no of clusters
+     * @return Map<String, ImmutableSet < MarkerGene>> of cluster MarkerGenes
+     * Objects as a value
+     */
+    public ImmutableList<MarkerGene> getMarkerGenesPerCluster(String experimentAccession, String k) {
+        return ImmutableList.copyOf(markerGenesDao.getMarkerGenesWithAveragesPerCluster(experimentAccession, k));
+    }
 }

--- a/src/main/java/uk/ac/ebi/atlas/experimentpage/markergenes/MarkerGeneService.java
+++ b/src/main/java/uk/ac/ebi/atlas/experimentpage/markergenes/MarkerGeneService.java
@@ -16,35 +16,35 @@ public class MarkerGeneService {
         this.cellTypeSearchDao = cellTypeSearchDao;
     }
 
-    /**
-     * Get ImmutableList of marker genes objects for an experiment of that organism part.
-     *
-     * @param organismPart
-     * @param experimentAccession
-     * @return ImmutableList of CellTypeMarkerGene Objects
-     */
-    public ImmutableList<MarkerGene> getCellTypeMarkerGeneProfile(String experimentAccession, String organismPart) {
+	/**
+	 * Get ImmutableList of marker genes objects for an experiment of that organism part.
+	 *
+	 * @param organismPart
+	 * @param experimentAccession
+	 * @return ImmutableList of CellTypeMarkerGene Objects
+	 */
+	public ImmutableList<MarkerGene> getCellTypeMarkerGeneProfile(String experimentAccession, String organismPart) {
 
-        var ontologyLabelsCellTypeValues = cellTypeSearchDao.getInferredCellTypeOntologyLabels(experimentAccession, organismPart);
+		var ontologyLabelsCellTypeValues = cellTypeSearchDao.getInferredCellTypeOntologyLabels(experimentAccession, organismPart);
 
-        var cellTypeMarkerGenes = ontologyLabelsCellTypeValues.isEmpty() ?
-                markerGenesDao.getCellTypeMarkerGenes(experimentAccession,
-                        cellTypeSearchDao.getInferredCellTypeAuthorsLabels(experimentAccession, organismPart)) :
-                markerGenesDao.getCellTypeMarkerGenes(experimentAccession, ontologyLabelsCellTypeValues);
+		var cellTypeMarkerGenes = ontologyLabelsCellTypeValues.isEmpty() ?
+				markerGenesDao.getCellTypeMarkerGenes(experimentAccession,
+						cellTypeSearchDao.getInferredCellTypeAuthorsLabels(experimentAccession, organismPart)) :
+				markerGenesDao.getCellTypeMarkerGenes(experimentAccession, ontologyLabelsCellTypeValues);
 
-        return cellTypeMarkerGenes.stream()
-                .filter(markerGene -> !markerGene.cellGroupValue().equalsIgnoreCase("Not available"))
-                .filter(markerGene -> !markerGene.cellGroupValueWhereMarker().equalsIgnoreCase("Not available"))
-                .collect(toImmutableList());
-    }
+		return cellTypeMarkerGenes.stream()
+				.filter(markerGene -> !markerGene.cellGroupValue().equalsIgnoreCase("Not available"))
+				.filter(markerGene -> !markerGene.cellGroupValueWhereMarker().equalsIgnoreCase("Not available"))
+				.collect(toImmutableList());
+	}
 
-    /**
-     * @param experimentAccession - Id of the experiment
-     * @param k                   - no of clusters
-     * @return Map<String, ImmutableSet < MarkerGene>> of cluster MarkerGenes
-     * Objects as a value
-     */
-    public ImmutableList<MarkerGene> getMarkerGenesPerCluster(String experimentAccession, String k) {
-        return ImmutableList.copyOf(markerGenesDao.getMarkerGenesWithAveragesPerCluster(experimentAccession, k));
-    }
+	/**
+	 * @param experimentAccession - Id of the experiment
+	 * @param k                   - no of clusters
+	 * @return Map<String, ImmutableSet < MarkerGene>> of cluster MarkerGenes
+	 * Objects as a value
+	 */
+	public ImmutableList<MarkerGene> getMarkerGenesPerCluster(String experimentAccession, String k) {
+		return ImmutableList.copyOf(markerGenesDao.getMarkerGenesWithAveragesPerCluster(experimentAccession, k));
+	}
 }

--- a/src/main/java/uk/ac/ebi/atlas/experimentpage/tabs/ExperimentPageContentService.java
+++ b/src/main/java/uk/ac/ebi/atlas/experimentpage/tabs/ExperimentPageContentService.java
@@ -2,6 +2,7 @@ package uk.ac.ebi.atlas.experimentpage.tabs;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
@@ -34,7 +35,7 @@ public class ExperimentPageContentService {
     private final OntologyAccessionsSearchService ontologyAccessionsSearchService;
     private final ExperimentTrader experimentTrader;
 
-    private final static List<String> EXPERIMENTS_WITH_NO_ANATOMOGRAM = ImmutableList.of(
+    private final static ImmutableSet<String> EXPERIMENTS_WITH_NO_ANATOMOGRAM = ImmutableSet.of(
             "E-GEOD-130473",
             "E-HCAD-8",
             "E-MTAB-6653",

--- a/src/main/java/uk/ac/ebi/atlas/experimentpage/tabs/ExperimentPageContentService.java
+++ b/src/main/java/uk/ac/ebi/atlas/experimentpage/tabs/ExperimentPageContentService.java
@@ -82,7 +82,10 @@ public class ExperimentPageContentService {
 
         result.addProperty("suggesterEndpoint", "json/suggestions");
 
-        if(!EXPERIMENTS_WITH_NO_ANATOMOGRAM.contains(experimentAccession)) {
+        if (EXPERIMENTS_WITH_NO_ANATOMOGRAM.contains(experimentAccession)) {
+            result.add(
+                    "anatomogram", GSON.toJsonTree(""));
+        } else {
             result.add(
                     "anatomogram",
                     GSON.toJsonTree(

--- a/src/main/java/uk/ac/ebi/atlas/experimentpage/tabs/ExperimentPageContentService.java
+++ b/src/main/java/uk/ac/ebi/atlas/experimentpage/tabs/ExperimentPageContentService.java
@@ -82,16 +82,11 @@ public class ExperimentPageContentService {
 
         result.addProperty("suggesterEndpoint", "json/suggestions");
 
-        if (EXPERIMENTS_WITH_NO_ANATOMOGRAM.contains(experimentAccession)) {
-            result.add(
-                    "anatomogram", GSON.toJsonTree(""));
-        } else {
-            result.add(
-                    "anatomogram",
-                    GSON.toJsonTree(
-                            ontologyAccessionsSearchService.searchAvailableAnnotationsForOrganAnatomogram(
-                                    experimentAccession)));
-        }
+        result.add(
+                "anatomogram",
+                GSON.toJsonTree(EXPERIMENTS_WITH_NO_ANATOMOGRAM.contains(experimentAccession) ?
+                        "" :
+                        ontologyAccessionsSearchService.searchAvailableAnnotationsForOrganAnatomogram(experimentAccession)));
 
         return result;
     }

--- a/src/main/java/uk/ac/ebi/atlas/experimentpage/tabs/ExperimentPageContentService.java
+++ b/src/main/java/uk/ac/ebi/atlas/experimentpage/tabs/ExperimentPageContentService.java
@@ -34,6 +34,17 @@ public class ExperimentPageContentService {
     private final OntologyAccessionsSearchService ontologyAccessionsSearchService;
     private final ExperimentTrader experimentTrader;
 
+    private final static List<String> EXPERIMENTS_WITH_NO_ANATOMOGRAM = ImmutableList.of(
+            "E-GEOD-130473",
+            "E-HCAD-8",
+            "E-MTAB-6653",
+            "E-GEOD-86618",
+            "E-CURD-11",
+            "E-MTAB-6308",
+            "E-HCAD-10",
+            "E-CURD-10"
+    );
+
     public ExperimentPageContentService(ExperimentFileLocationService experimentFileLocationService,
                                         DataFileHub dataFileHub,
                                         TSnePlotSettingsService tsnePlotSettingsService,
@@ -70,11 +81,13 @@ public class ExperimentPageContentService {
 
         result.addProperty("suggesterEndpoint", "json/suggestions");
 
-        result.add(
-                "anatomogram",
-                GSON.toJsonTree(
-                        ontologyAccessionsSearchService.searchAvailableAnnotationsForOrganAnatomogram(
-                                experimentAccession)));
+        if(!EXPERIMENTS_WITH_NO_ANATOMOGRAM.contains(experimentAccession)) {
+            result.add(
+                    "anatomogram",
+                    GSON.toJsonTree(
+                            ontologyAccessionsSearchService.searchAvailableAnnotationsForOrganAnatomogram(
+                                    experimentAccession)));
+        }
 
         return result;
     }

--- a/src/test/java/uk/ac/ebi/atlas/experimentpage/tabs/ExperimentPageContentServiceIT.java
+++ b/src/test/java/uk/ac/ebi/atlas/experimentpage/tabs/ExperimentPageContentServiceIT.java
@@ -198,7 +198,7 @@ class ExperimentPageContentServiceIT {
 
     @Test
     void anatomogramDoesNotExistsForValidExperiment() {
-        var experimentAccession = "E-HCAD-8";
+        var experimentAccession = "E-MTAB-6308";
         var result = this.subject.getTsnePlotData(experimentAccession);
 
         assertThat(result.has("anatomogram")).isFalse();

--- a/src/test/java/uk/ac/ebi/atlas/experimentpage/tabs/ExperimentPageContentServiceIT.java
+++ b/src/test/java/uk/ac/ebi/atlas/experimentpage/tabs/ExperimentPageContentServiceIT.java
@@ -198,7 +198,7 @@ class ExperimentPageContentServiceIT {
 
     @Test
     void anatomogramDoesNotExistsForValidExperiment() {
-        var experimentAccession = "E-MTAB-6308";
+        var experimentAccession = "E-GEOD-130473";
         var result = this.subject.getTsnePlotData(experimentAccession);
 
         assertThat(result.has("anatomogram")).isFalse();

--- a/src/test/java/uk/ac/ebi/atlas/experimentpage/tabs/ExperimentPageContentServiceIT.java
+++ b/src/test/java/uk/ac/ebi/atlas/experimentpage/tabs/ExperimentPageContentServiceIT.java
@@ -187,4 +187,20 @@ class ExperimentPageContentServiceIT {
         assertThat(result.has("units")).isTrue();
         assertThat(result.get("units").getAsJsonArray()).isNotEmpty();
     }
+
+    @Test
+    void anatomogramExistsForValidExperiment() {
+        var experimentAccession = "E-MTAB-5061";
+        var result = this.subject.getTsnePlotData(experimentAccession);
+
+        assertThat(result.has("anatomogram")).isTrue();
+    }
+
+    @Test
+    void anatomogramDoesNotExistsForValidExperiment() {
+        var experimentAccession = "E-HCAD-8";
+        var result = this.subject.getTsnePlotData(experimentAccession);
+
+        assertThat(result.has("anatomogram")).isFalse();
+    }
 }

--- a/src/test/java/uk/ac/ebi/atlas/experimentpage/tabs/ExperimentPageContentServiceIT.java
+++ b/src/test/java/uk/ac/ebi/atlas/experimentpage/tabs/ExperimentPageContentServiceIT.java
@@ -195,12 +195,4 @@ class ExperimentPageContentServiceIT {
 
         assertThat(result.has("anatomogram")).isTrue();
     }
-
-    @Test
-    void anatomogramDoesNotExistsForValidExperiment() {
-        var experimentAccession = "E-GEOD-130473";
-        var result = this.subject.getTsnePlotData(experimentAccession);
-
-        assertThat(result.has("anatomogram")).isFalse();
-    }
 }

--- a/src/test/java/uk/ac/ebi/atlas/experimentpage/tabs/ExperimentPageContentServiceTest.java
+++ b/src/test/java/uk/ac/ebi/atlas/experimentpage/tabs/ExperimentPageContentServiceTest.java
@@ -180,9 +180,9 @@ class ExperimentPageContentServiceTest {
 
     @Test
     void anatomogramDoesNotExistsForValidExperiment() {
-        assertThat(this.subject
-                .getTsnePlotData(NON_ANATOMOGRAM_EXPERIMENT_ACCESSION)
-                .has("anatomogram"))
-                .isFalse();
+        var result = this.subject.getTsnePlotData(NON_ANATOMOGRAM_EXPERIMENT_ACCESSION);
+
+        assertThat(result.has("anatomogram")).isTrue();
+        assertThat(result.get("anatomogram").getAsString()).isEqualToIgnoringCase("");
     }
 }


### PR DESCRIPTION
For experiments with incomplete anatomogram data, they should not display anatomograms. See issue here:

https://github.com/ebi-gene-expression-group/atlas-web-single-cell/issues/127