### PR TITLE
Feature #176761932 – Send multiple onotology uris to back end

### DIFF
--- a/src/main/javascript/bundles/experiment-page/src/results/AnatomogramCellTypeHeatmapView.js
+++ b/src/main/javascript/bundles/experiment-page/src/results/AnatomogramCellTypeHeatmapView.js
@@ -46,32 +46,34 @@ class AnatomogramCellTypeHeatmapView extends React.Component {
   }
 
   _addRemoveFromSelectIds(ids) {
-    let selectedAccessionOrLinkAccession = ids[0]
+    let selectedAccessionOrLinkAccession = ids
     if (ids[0] === `link_islet_of_langerhans`) {
-      selectedAccessionOrLinkAccession = `UBERON_0001264`
+      selectedAccessionOrLinkAccession = [`UBERON_0001264`]
     } else if (ids[0] === `link_glomerulus`) {
-      selectedAccessionOrLinkAccession = `UBERON_0000074`
+      selectedAccessionOrLinkAccession = [`UBERON_0000074`]
     } else if (ids[0] === `link_duct`) {
-      selectedAccessionOrLinkAccession = `UBERON_0001232`
+      selectedAccessionOrLinkAccession = [`UBERON_0001232`]
     } else if (ids[0] === `link_nephron`) {
-      selectedAccessionOrLinkAccession = `UBERON_0001285`
+      selectedAccessionOrLinkAccession = [`UBERON_0001285`]
     } else if (ids[0] === `link_lobule_of_liver`) {
-      selectedAccessionOrLinkAccession = `UBERON_0004647`
+      selectedAccessionOrLinkAccession = [`UBERON_0004647`]
     } else if (ids[0] === `link_alveoli`) {
-      selectedAccessionOrLinkAccession = `UBERON_0002299`
+      selectedAccessionOrLinkAccession = [`UBERON_0002299`]
     } else if (ids[0] === `link_segmental_bronchus`) {
-      selectedAccessionOrLinkAccession = `UBERON_0002184`
+      selectedAccessionOrLinkAccession = [`UBERON_0002184`]
     } else if (ids[0] === `link_alveolus_section`) {
-      selectedAccessionOrLinkAccession = `UBERON_0003215`
+      selectedAccessionOrLinkAccession = [`UBERON_0003215`]
     } else if (ids[0] === `link_cell_level`) {
-      selectedAccessionOrLinkAccession = `UBERON_0001987`
+      selectedAccessionOrLinkAccession =
+        [`CL_2000002`,  `EFO_0010710`, `CL_3000001`, `UBERON_0000371`, `UBERON_0000319`, `UBERON_0000426`,
+         `EFO_0010712`, `EFO_0010711`, `CL_0002601`, `EFO_0010708`]
     }
 
     this.setState({
       selectIds: ids,
       resource:
         URI(`json/experiments/${this.props.experimentAccession}/marker-genes/cell-types`, this.props.host)
-          .search({organismPart: ontologyAccessionToOntologyUri(selectedAccessionOrLinkAccession)})
+          .search({organismPart: selectedAccessionOrLinkAccession.map(ontologyAccessionToOntologyUri).join(`,`)})
           .toString()
     })
   }

--- a/src/main/javascript/bundles/experiment-page/src/results/AnatomogramCellTypeHeatmapView.js
+++ b/src/main/javascript/bundles/experiment-page/src/results/AnatomogramCellTypeHeatmapView.js
@@ -56,17 +56,28 @@ class AnatomogramCellTypeHeatmapView extends React.Component {
     } else if (ids[0] === `link_nephron`) {
       selectedAccessionOrLinkAccession = [`UBERON_0001285`]
     } else if (ids[0] === `link_lobule_of_liver`) {
-      selectedAccessionOrLinkAccession = [`UBERON_0004647`]
+      selectedAccessionOrLinkAccession = [ // `UBERON_0004647`,
+        `CL_0000182`, `CL_0000632`, `UBERON_0001282`, `CL_1000488`, `UBERON_0001193`, `UBERON_0006841`,
+        `UBERON_0001639`, `EFO_0010704`, `UBERON_0001281`, `CL_1000398`, `EFO_0010705`, `EFO_0010706`, `CL_0000091`
+      ]
     } else if (ids[0] === `link_alveoli`) {
-      selectedAccessionOrLinkAccession = [`UBERON_0002299`]
+      selectedAccessionOrLinkAccession = [
+        `UBERON_0002299`, `UBERON_0002188`, `UBERON_0016405`
+      ]
     } else if (ids[0] === `link_segmental_bronchus`) {
-      selectedAccessionOrLinkAccession = [`UBERON_0002184`]
+      selectedAccessionOrLinkAccession = [ //`UBERON_0002184`,
+        `CL_0002633`, `CL_1001567`,  `CL_1000271`, `CL_0000158`, `EFO_0010666`, `CL_0002370`, `UBERON_0003504`,
+        `CL_0002598`
+      ]
     } else if (ids[0] === `link_alveolus_section`) {
-      selectedAccessionOrLinkAccession = [`UBERON_0003215`]
+      selectedAccessionOrLinkAccession = [ // `UBERON_0003215`,
+        `CL_0002062`, `CL_0002063`, `UBERON_0003456`, `EFO_0010667`, `EFO_0010668`, `EFO_0010669`
+      ]
     } else if (ids[0] === `link_cell_level`) {
-      selectedAccessionOrLinkAccession =
-        [`CL_2000002`,  `EFO_0010710`, `CL_3000001`, `UBERON_0000371`, `UBERON_0000319`, `UBERON_0000426`,
-         `EFO_0010712`, `EFO_0010711`, `CL_0002601`, `EFO_0010708`]
+      selectedAccessionOrLinkAccession = [
+        `CL_2000002`, `EFO_0010710`, `CL_3000001`, `UBERON_0000371`, `UBERON_0000319`, `UBERON_0000426`,
+        `EFO_0010712`, `EFO_0010711`, `CL_0002601`, `EFO_0010708`
+      ]
     }
 
     this.setState({


### PR DESCRIPTION
I expanded the views which weren’t covered by a single ontology ID to the correspondin arrays and passed a set of values in the request parameter `organismPart`.