### PR TITLE
Chore – Make analytics index build more robust

### DIFF
--- a/src/main/java/uk/ac/ebi/atlas/bioentity/properties/ExpressedBioentityFinderImpl.java
+++ b/src/main/java/uk/ac/ebi/atlas/bioentity/properties/ExpressedBioentityFinderImpl.java
@@ -1,0 +1,24 @@
+package uk.ac.ebi.atlas.bioentity.properties;
+
+import org.springframework.stereotype.Service;
+import uk.ac.ebi.atlas.solr.cloud.SolrCloudCollectionProxyFactory;
+import uk.ac.ebi.atlas.solr.cloud.collections.Gene2ExperimentCollectionProxy;
+import uk.ac.ebi.atlas.solr.cloud.search.SolrQueryBuilder;
+
+@Service
+public class ExpressedBioentityFinderImpl implements ExpressedBioentityFinder {
+    private final Gene2ExperimentCollectionProxy gene2ExperimentCollectionProxy;
+
+    public ExpressedBioentityFinderImpl(SolrCloudCollectionProxyFactory collectionProxyFactory) {
+        this.gene2ExperimentCollectionProxy = collectionProxyFactory.create(Gene2ExperimentCollectionProxy.class);
+    }
+
+    @Override
+    public boolean bioentityIsExpressedInAtLeastOneExperiment(String bioentityIdentifier) {
+        var solrQueryBuilder =
+                new SolrQueryBuilder<Gene2ExperimentCollectionProxy>()
+                        .addQueryFieldByTerm(Gene2ExperimentCollectionProxy.BIOENTITY_IDENTIFIER, bioentityIdentifier);
+
+        return gene2ExperimentCollectionProxy.query(solrQueryBuilder).getResults().size() > 0;
+    }
+}

--- a/src/main/java/uk/ac/ebi/atlas/configuration/AppConfig.java
+++ b/src/main/java/uk/ac/ebi/atlas/configuration/AppConfig.java
@@ -5,6 +5,10 @@ import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.web.client.RestTemplate;
+import uk.ac.ebi.atlas.model.experiment.ExperimentType;
+import uk.ac.ebi.atlas.utils.BioentityIdentifiersReader;
+
+import java.util.HashSet;
 
 @Configuration
 @ComponentScan(basePackages = "uk.ac.ebi.atlas")
@@ -18,5 +22,20 @@ public class AppConfig {
         requestFactory.setConnectTimeout(MAX_TIMEOUT_MILLIS);
 
         return new RestTemplate(requestFactory);
+    }
+
+    @Bean
+    public BioentityIdentifiersReader bioentityIdentifiersReader() {
+        return new BioentityIdentifiersReader() {
+            @Override
+            protected int addBioentityIdentifiers(HashSet<String> bioentityIdentifiers, ExperimentType experimentType) {
+                return 0;
+            }
+
+            @Override
+            public HashSet<String> getBioentityIdsFromExperiment(String experimentAccession) {
+                return new HashSet<>();
+            }
+        };
     }
 }

--- a/src/main/java/uk/ac/ebi/atlas/configuration/AppConfig.java
+++ b/src/main/java/uk/ac/ebi/atlas/configuration/AppConfig.java
@@ -6,6 +6,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.web.client.RestTemplate;
 import uk.ac.ebi.atlas.model.experiment.ExperimentType;
+import uk.ac.ebi.atlas.species.SpeciesFinder;
 import uk.ac.ebi.atlas.utils.BioentityIdentifiersReader;
 
 import java.util.HashSet;
@@ -37,5 +38,10 @@ public class AppConfig {
                 return new HashSet<>();
             }
         };
+    }
+
+    @Bean
+    public SpeciesFinder speciesFinder() {
+        return new SpeciesFinder() {};
     }
 }

--- a/src/main/java/uk/ac/ebi/atlas/search/JsonBioentityInformationController.java
+++ b/src/main/java/uk/ac/ebi/atlas/search/JsonBioentityInformationController.java
@@ -20,10 +20,9 @@ import static uk.ac.ebi.atlas.utils.GsonProvider.GSON;
 
 @RestController
 public class JsonBioentityInformationController extends JsonExceptionHandlingController {
-
-    private BioEntityPropertyDao bioEntityPropertyDao;
-    private BioEntityCardModelFactory bioEntityCardModelFactory;
-    private SpeciesInferrer speciesInferrer;
+    private final BioEntityPropertyDao bioEntityPropertyDao;
+    private final BioEntityCardModelFactory bioEntityCardModelFactory;
+    private final SpeciesInferrer speciesInferrer;
 
     @Inject
     public JsonBioentityInformationController(BioEntityPropertyDao bioEntityPropertyDao,

--- a/src/test/java/uk/ac/ebi/atlas/bioentity/properties/ExpressedBioentityFinderImplIT.java
+++ b/src/test/java/uk/ac/ebi/atlas/bioentity/properties/ExpressedBioentityFinderImplIT.java
@@ -1,0 +1,43 @@
+package uk.ac.ebi.atlas.bioentity.properties;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.context.web.WebAppConfiguration;
+import uk.ac.ebi.atlas.configuration.TestConfig;
+import uk.ac.ebi.atlas.testutils.JdbcUtils;
+
+import javax.inject.Inject;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.AFTER_TEST_METHOD;
+import static uk.ac.ebi.atlas.testutils.RandomDataTestUtils.generateRandomEnsemblGeneId;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = TestConfig.class)
+@WebAppConfiguration
+@Sql("/fixtures/scxa_analytics-fixture.sql")
+@Sql(value = "/fixtures/scxa_analytics-delete.sql", executionPhase = AFTER_TEST_METHOD)
+class ExpressedBioentityFinderImplIT {
+    @Inject
+    JdbcUtils jdbcUtils;
+
+    @Inject
+    private ExpressedBioentityFinderImpl subject;
+
+    @Test
+    void unknownGeneIdIsNotExpressed() {
+        assertThat(subject.bioentityIsExpressedInAtLeastOneExperiment(generateRandomEnsemblGeneId()))
+                .isFalse();
+    }
+
+    @Test
+    void expressedGeneIdIsExpressed() {
+        var geneId = jdbcUtils.fetchRandomGene();
+
+        assertThat(subject.bioentityIsExpressedInAtLeastOneExperiment(geneId))
+                .isTrue();
+    }
+}

--- a/src/test/java/uk/ac/ebi/atlas/configuration/TestConfig.java
+++ b/src/test/java/uk/ac/ebi/atlas/configuration/TestConfig.java
@@ -6,6 +6,10 @@ import org.springframework.context.annotation.ComponentScan.Filter;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.FilterType;
 import org.springframework.web.client.RestTemplate;
+import uk.ac.ebi.atlas.model.experiment.ExperimentType;
+import uk.ac.ebi.atlas.utils.BioentityIdentifiersReader;
+
+import java.util.HashSet;
 
 @Configuration
 // Enabling component scanning will also load BasePathsConfig, JdbcConfig and SolrConfig, so just using this class as
@@ -21,5 +25,20 @@ public class TestConfig {
     @Bean
     public RestTemplate restTemplate() {
         return new RestTemplate();
+    }
+
+    @Bean
+    public BioentityIdentifiersReader bioentityIdentifiersReader() {
+        return new BioentityIdentifiersReader() {
+            @Override
+            protected int addBioentityIdentifiers(HashSet<String> bioentityIdentifiers, ExperimentType experimentType) {
+                return 0;
+            }
+
+            @Override
+            public HashSet<String> getBioentityIdsFromExperiment(String experimentAccession) {
+                return new HashSet<>();
+            }
+        };
     }
 }

--- a/src/test/java/uk/ac/ebi/atlas/configuration/TestConfig.java
+++ b/src/test/java/uk/ac/ebi/atlas/configuration/TestConfig.java
@@ -7,6 +7,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.FilterType;
 import org.springframework.web.client.RestTemplate;
 import uk.ac.ebi.atlas.model.experiment.ExperimentType;
+import uk.ac.ebi.atlas.species.SpeciesFinder;
 import uk.ac.ebi.atlas.utils.BioentityIdentifiersReader;
 
 import java.util.HashSet;
@@ -40,5 +41,10 @@ public class TestConfig {
                 return new HashSet<>();
             }
         };
+    }
+
+    @Bean
+    public SpeciesFinder speciesFinder() {
+        return new SpeciesFinder() {};
     }
 }

--- a/src/test/java/uk/ac/ebi/atlas/download/ExperimentFileLocationServiceIT.java
+++ b/src/test/java/uk/ac/ebi/atlas/download/ExperimentFileLocationServiceIT.java
@@ -90,12 +90,12 @@ class ExperimentFileLocationServiceIT {
 	void cleanDatabaseTables() {
 		ResourceDatabasePopulator populator = new ResourceDatabasePopulator();
 		populator.addScripts(
-				new ClassPathResource("fixtures/experiment-delete.sql"),
-				new ClassPathResource("fixtures/scxa_cell_clusters-delete.sql"),
-				new ClassPathResource("fixtures/scxa_cell_group-delete.sql"),
-				new ClassPathResource("fixtures/scxa_cell_group_membership-delete.sql"),
+				new ClassPathResource("fixtures/scxa_cell_group_marker_gene_stats-delete.sql"),
 				new ClassPathResource("fixtures/scxa_cell_group_marker_genes-delete.sql"),
-				new ClassPathResource("fixtures/scxa_cell_group_marker_gene_stats-delete.sql"));
+				new ClassPathResource("fixtures/scxa_cell_group_membership-delete.sql"),
+				new ClassPathResource("fixtures/scxa_cell_group-delete.sql"),
+				new ClassPathResource("fixtures/scxa_cell_clusters-delete.sql"),
+				new ClassPathResource("fixtures/experiment-delete.sql"));
 		populator.execute(dataSource);
 	}
 

--- a/src/test/java/uk/ac/ebi/atlas/experimentimport/ScxaExperimentCrudIT.java
+++ b/src/test/java/uk/ac/ebi/atlas/experimentimport/ScxaExperimentCrudIT.java
@@ -21,6 +21,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
+import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.AFTER_TEST_METHOD;
 import static uk.ac.ebi.atlas.testutils.RandomDataTestUtils.generateRandomExperimentAccession;
 
 @WebAppConfiguration
@@ -28,6 +29,7 @@ import static uk.ac.ebi.atlas.testutils.RandomDataTestUtils.generateRandomExperi
 @ContextConfiguration(classes = TestConfig.class)
 @Transactional
 @Sql("/fixtures/experiment-fixture.sql")
+@Sql(scripts = "/fixtures/experiment-delete.sql", executionPhase = AFTER_TEST_METHOD)
 class ScxaExperimentCrudIT {
     private static final Random RNG = ThreadLocalRandom.current();
 

--- a/src/test/java/uk/ac/ebi/atlas/experimentimport/ScxaExperimentCrudIT.java
+++ b/src/test/java/uk/ac/ebi/atlas/experimentimport/ScxaExperimentCrudIT.java
@@ -1,90 +1,90 @@
-package uk.ac.ebi.atlas.experimentimport;
-
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.jdbc.Sql;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
-import org.springframework.test.context.web.WebAppConfiguration;
-import org.springframework.transaction.annotation.Transactional;
-import uk.ac.ebi.atlas.configuration.TestConfig;
-import uk.ac.ebi.atlas.controllers.ResourceNotFoundException;
-import uk.ac.ebi.atlas.testutils.JdbcUtils;
-
-import javax.inject.Inject;
-import java.util.Random;
-import java.util.concurrent.ThreadLocalRandom;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verify;
-import static uk.ac.ebi.atlas.testutils.RandomDataTestUtils.generateRandomExperimentAccession;
-
-@WebAppConfiguration
-@ExtendWith(SpringExtension.class)
-@ContextConfiguration(classes = TestConfig.class)
-@Transactional
-@Sql("/fixtures/experiment-fixture.sql")
-class ScxaExperimentCrudIT {
-    private static final Random RNG = ThreadLocalRandom.current();
-
-    @Inject
-    private JdbcUtils jdbcUtils;
-
-    @Inject
-    private ScxaExperimentCrud subject;
-
-    @Test
-    void createExperiment() {
-        var experimentAccession = jdbcUtils.fetchRandomExperimentAccession();
-        subject.deleteExperiment(experimentAccession);
-        assertThat(subject.readExperiment(experimentAccession))
-                .isEmpty();
-
-        subject.createExperiment(experimentAccession, RNG.nextBoolean());
-        assertThat(subject.readExperiment(experimentAccession))
-                .isPresent()
-                .get().hasNoNullFieldsOrProperties();
-    }
-
-    @Test
-    void throwsIfExperimentFilesCannotBeFound() {
-        assertThatExceptionOfType(RuntimeException.class)
-                .isThrownBy(() -> subject.createExperiment(generateRandomExperimentAccession(), RNG.nextBoolean()));
-    }
-
-    @Test
-    void updatesLastUpdateIfExperimentIsAlreadyPresent() {
-        var experimentAccession = jdbcUtils.fetchRandomExperimentAccession();
-        var experimentBeforeUpdate = subject.readExperiment(experimentAccession).orElseThrow();
-        var lastUpdateBeforeUpdate = experimentBeforeUpdate.getLastUpdate();
-
-        subject.createExperiment(experimentAccession, RNG.nextBoolean());
-        assertThat(subject.readExperiment(experimentAccession)).get()
-                .isEqualToIgnoringGivenFields(experimentBeforeUpdate, "lastUpdate", "isPrivate");
-        assertThat(subject.readExperiment(experimentAccession).orElseThrow().getLastUpdate())
-                .isAfter(lastUpdateBeforeUpdate);
-    }
-
-    @Test
-    void throwIfExperimentDoesNotExistUpdateExperimentDesign() {
-        assertThatExceptionOfType(ResourceNotFoundException.class)
-                .isThrownBy(() -> subject.updateExperimentDesign(generateRandomExperimentAccession()));
-    }
-
-    @Test
-    void updateDesignCallsUpdateDesignInSuperClass() {
-         var spy = spy(subject);
-
-        var experimentAccession = jdbcUtils.fetchRandomExperimentAccession();
-        spy.updateExperimentDesign(experimentAccession);
-
-        verify(spy)
-                .updateExperimentDesign(
-                        any(),
-                        eq(subject.readExperiment(experimentAccession).orElseThrow()));
-    }
-}
+//package uk.ac.ebi.atlas.experimentimport;
+//
+//import org.junit.jupiter.api.Test;
+//import org.junit.jupiter.api.extension.ExtendWith;
+//import org.springframework.test.context.ContextConfiguration;
+//import org.springframework.test.context.jdbc.Sql;
+//import org.springframework.test.context.junit.jupiter.SpringExtension;
+//import org.springframework.test.context.web.WebAppConfiguration;
+//import org.springframework.transaction.annotation.Transactional;
+//import uk.ac.ebi.atlas.configuration.TestConfig;
+//import uk.ac.ebi.atlas.controllers.ResourceNotFoundException;
+//import uk.ac.ebi.atlas.testutils.JdbcUtils;
+//
+//import javax.inject.Inject;
+//import java.util.Random;
+//import java.util.concurrent.ThreadLocalRandom;
+//
+//import static org.assertj.core.api.Assertions.assertThat;
+//import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+//import static org.mockito.ArgumentMatchers.any;
+//import static org.mockito.ArgumentMatchers.eq;
+//import static org.mockito.Mockito.spy;
+//import static org.mockito.Mockito.verify;
+//import static uk.ac.ebi.atlas.testutils.RandomDataTestUtils.generateRandomExperimentAccession;
+//
+//@WebAppConfiguration
+//@ExtendWith(SpringExtension.class)
+//@ContextConfiguration(classes = TestConfig.class)
+//@Transactional
+//@Sql("/fixtures/experiment-fixture.sql")
+//class ScxaExperimentCrudIT {
+//    private static final Random RNG = ThreadLocalRandom.current();
+//
+//    @Inject
+//    private JdbcUtils jdbcUtils;
+//
+//    @Inject
+//    private ScxaExperimentCrud subject;
+//
+//    @Test
+//    void createExperiment() {
+//        var experimentAccession = jdbcUtils.fetchRandomExperimentAccession();
+//        subject.deleteExperiment(experimentAccession);
+//        assertThat(subject.readExperiment(experimentAccession))
+//                .isEmpty();
+//
+//        subject.createExperiment(experimentAccession, RNG.nextBoolean());
+//        assertThat(subject.readExperiment(experimentAccession))
+//                .isPresent()
+//                .get().hasNoNullFieldsOrProperties();
+//    }
+//
+//    @Test
+//    void throwsIfExperimentFilesCannotBeFound() {
+//        assertThatExceptionOfType(RuntimeException.class)
+//                .isThrownBy(() -> subject.createExperiment(generateRandomExperimentAccession(), RNG.nextBoolean()));
+//    }
+//
+//    @Test
+//    void updatesLastUpdateIfExperimentIsAlreadyPresent() {
+//        var experimentAccession = jdbcUtils.fetchRandomExperimentAccession();
+//        var experimentBeforeUpdate = subject.readExperiment(experimentAccession).orElseThrow();
+//        var lastUpdateBeforeUpdate = experimentBeforeUpdate.getLastUpdate();
+//
+//        subject.createExperiment(experimentAccession, RNG.nextBoolean());
+//        assertThat(subject.readExperiment(experimentAccession)).get()
+//                .isEqualToIgnoringGivenFields(experimentBeforeUpdate, "lastUpdate", "isPrivate");
+//        assertThat(subject.readExperiment(experimentAccession).orElseThrow().getLastUpdate())
+//                .isAfter(lastUpdateBeforeUpdate);
+//    }
+//
+//    @Test
+//    void throwIfExperimentDoesNotExistUpdateExperimentDesign() {
+//        assertThatExceptionOfType(ResourceNotFoundException.class)
+//                .isThrownBy(() -> subject.updateExperimentDesign(generateRandomExperimentAccession()));
+//    }
+//
+//    @Test
+//    void updateDesignCallsUpdateDesignInSuperClass() {
+//         var spy = spy(subject);
+//
+//        var experimentAccession = jdbcUtils.fetchRandomExperimentAccession();
+//        spy.updateExperimentDesign(experimentAccession);
+//
+//        verify(spy)
+//                .updateExperimentDesign(
+//                        any(),
+//                        eq(subject.readExperiment(experimentAccession).orElseThrow()));
+//    }
+//}

--- a/src/test/java/uk/ac/ebi/atlas/experimentimport/ScxaExperimentCrudIT.java
+++ b/src/test/java/uk/ac/ebi/atlas/experimentimport/ScxaExperimentCrudIT.java
@@ -1,90 +1,90 @@
-//package uk.ac.ebi.atlas.experimentimport;
-//
-//import org.junit.jupiter.api.Test;
-//import org.junit.jupiter.api.extension.ExtendWith;
-//import org.springframework.test.context.ContextConfiguration;
-//import org.springframework.test.context.jdbc.Sql;
-//import org.springframework.test.context.junit.jupiter.SpringExtension;
-//import org.springframework.test.context.web.WebAppConfiguration;
-//import org.springframework.transaction.annotation.Transactional;
-//import uk.ac.ebi.atlas.configuration.TestConfig;
-//import uk.ac.ebi.atlas.controllers.ResourceNotFoundException;
-//import uk.ac.ebi.atlas.testutils.JdbcUtils;
-//
-//import javax.inject.Inject;
-//import java.util.Random;
-//import java.util.concurrent.ThreadLocalRandom;
-//
-//import static org.assertj.core.api.Assertions.assertThat;
-//import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-//import static org.mockito.ArgumentMatchers.any;
-//import static org.mockito.ArgumentMatchers.eq;
-//import static org.mockito.Mockito.spy;
-//import static org.mockito.Mockito.verify;
-//import static uk.ac.ebi.atlas.testutils.RandomDataTestUtils.generateRandomExperimentAccession;
-//
-//@WebAppConfiguration
-//@ExtendWith(SpringExtension.class)
-//@ContextConfiguration(classes = TestConfig.class)
-//@Transactional
-//@Sql("/fixtures/experiment-fixture.sql")
-//class ScxaExperimentCrudIT {
-//    private static final Random RNG = ThreadLocalRandom.current();
-//
-//    @Inject
-//    private JdbcUtils jdbcUtils;
-//
-//    @Inject
-//    private ScxaExperimentCrud subject;
-//
-//    @Test
-//    void createExperiment() {
-//        var experimentAccession = jdbcUtils.fetchRandomExperimentAccession();
-//        subject.deleteExperiment(experimentAccession);
-//        assertThat(subject.readExperiment(experimentAccession))
-//                .isEmpty();
-//
-//        subject.createExperiment(experimentAccession, RNG.nextBoolean());
-//        assertThat(subject.readExperiment(experimentAccession))
-//                .isPresent()
-//                .get().hasNoNullFieldsOrProperties();
-//    }
-//
-//    @Test
-//    void throwsIfExperimentFilesCannotBeFound() {
-//        assertThatExceptionOfType(RuntimeException.class)
-//                .isThrownBy(() -> subject.createExperiment(generateRandomExperimentAccession(), RNG.nextBoolean()));
-//    }
-//
-//    @Test
-//    void updatesLastUpdateIfExperimentIsAlreadyPresent() {
-//        var experimentAccession = jdbcUtils.fetchRandomExperimentAccession();
-//        var experimentBeforeUpdate = subject.readExperiment(experimentAccession).orElseThrow();
-//        var lastUpdateBeforeUpdate = experimentBeforeUpdate.getLastUpdate();
-//
-//        subject.createExperiment(experimentAccession, RNG.nextBoolean());
-//        assertThat(subject.readExperiment(experimentAccession)).get()
-//                .isEqualToIgnoringGivenFields(experimentBeforeUpdate, "lastUpdate", "isPrivate");
-//        assertThat(subject.readExperiment(experimentAccession).orElseThrow().getLastUpdate())
-//                .isAfter(lastUpdateBeforeUpdate);
-//    }
-//
-//    @Test
-//    void throwIfExperimentDoesNotExistUpdateExperimentDesign() {
-//        assertThatExceptionOfType(ResourceNotFoundException.class)
-//                .isThrownBy(() -> subject.updateExperimentDesign(generateRandomExperimentAccession()));
-//    }
-//
-//    @Test
-//    void updateDesignCallsUpdateDesignInSuperClass() {
-//         var spy = spy(subject);
-//
-//        var experimentAccession = jdbcUtils.fetchRandomExperimentAccession();
-//        spy.updateExperimentDesign(experimentAccession);
-//
-//        verify(spy)
-//                .updateExperimentDesign(
-//                        any(),
-//                        eq(subject.readExperiment(experimentAccession).orElseThrow()));
-//    }
-//}
+package uk.ac.ebi.atlas.experimentimport;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.transaction.annotation.Transactional;
+import uk.ac.ebi.atlas.configuration.TestConfig;
+import uk.ac.ebi.atlas.controllers.ResourceNotFoundException;
+import uk.ac.ebi.atlas.testutils.JdbcUtils;
+
+import javax.inject.Inject;
+import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static uk.ac.ebi.atlas.testutils.RandomDataTestUtils.generateRandomExperimentAccession;
+
+@WebAppConfiguration
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = TestConfig.class)
+@Transactional
+@Sql("/fixtures/experiment-fixture.sql")
+class ScxaExperimentCrudIT {
+    private static final Random RNG = ThreadLocalRandom.current();
+
+    @Inject
+    private JdbcUtils jdbcUtils;
+
+    @Inject
+    private ScxaExperimentCrud subject;
+
+    @Test
+    void createExperiment() {
+        var experimentAccession = jdbcUtils.fetchRandomExperimentAccession();
+        subject.deleteExperiment(experimentAccession);
+        assertThat(subject.readExperiment(experimentAccession))
+                .isEmpty();
+
+        subject.createExperiment(experimentAccession, RNG.nextBoolean());
+        assertThat(subject.readExperiment(experimentAccession))
+                .isPresent()
+                .get().hasNoNullFieldsOrProperties();
+    }
+
+    @Test
+    void throwsIfExperimentFilesCannotBeFound() {
+        assertThatExceptionOfType(RuntimeException.class)
+                .isThrownBy(() -> subject.createExperiment(generateRandomExperimentAccession(), RNG.nextBoolean()));
+    }
+
+    @Test
+    void updatesLastUpdateIfExperimentIsAlreadyPresent() {
+        var experimentAccession = jdbcUtils.fetchRandomExperimentAccession();
+        var experimentBeforeUpdate = subject.readExperiment(experimentAccession).orElseThrow();
+        var lastUpdateBeforeUpdate = experimentBeforeUpdate.getLastUpdate();
+
+        subject.createExperiment(experimentAccession, RNG.nextBoolean());
+        assertThat(subject.readExperiment(experimentAccession)).get()
+                .isEqualToIgnoringGivenFields(experimentBeforeUpdate, "lastUpdate", "isPrivate");
+        assertThat(subject.readExperiment(experimentAccession).orElseThrow().getLastUpdate())
+                .isAfter(lastUpdateBeforeUpdate);
+    }
+
+    @Test
+    void throwIfExperimentDoesNotExistUpdateExperimentDesign() {
+        assertThatExceptionOfType(ResourceNotFoundException.class)
+                .isThrownBy(() -> subject.updateExperimentDesign(generateRandomExperimentAccession()));
+    }
+
+    @Test
+    void updateDesignCallsUpdateDesignInSuperClass() {
+         var spy = spy(subject);
+
+        var experimentAccession = jdbcUtils.fetchRandomExperimentAccession();
+        spy.updateExperimentDesign(experimentAccession);
+
+        verify(spy)
+                .updateExperimentDesign(
+                        any(),
+                        eq(subject.readExperiment(experimentAccession).orElseThrow()));
+    }
+}

--- a/src/test/java/uk/ac/ebi/atlas/experimentpage/JsonCellMetadataControllerWIT.java
+++ b/src/test/java/uk/ac/ebi/atlas/experimentpage/JsonCellMetadataControllerWIT.java
@@ -62,8 +62,8 @@ class JsonCellMetadataControllerWIT {
     void cleanDatabaseTables() {
         var populator = new ResourceDatabasePopulator();
         populator.addScripts(
-                new ClassPathResource("fixtures/experiment-delete.sql"),
-                new ClassPathResource("fixtures/scxa_analytics-delete.sql"));
+                new ClassPathResource("fixtures/scxa_analytics-delete.sql"),
+                new ClassPathResource("fixtures/experiment-delete.sql"));
         populator.execute(dataSource);
     }
 

--- a/src/test/java/uk/ac/ebi/atlas/experimentpage/JsonTSnePlotControllerWIT.java
+++ b/src/test/java/uk/ac/ebi/atlas/experimentpage/JsonTSnePlotControllerWIT.java
@@ -66,12 +66,12 @@ class JsonTSnePlotControllerWIT {
     void cleanDatabaseTables() {
         ResourceDatabasePopulator populator = new ResourceDatabasePopulator();
         populator.addScripts(
-                new ClassPathResource("fixtures/experiment-delete.sql"),
-                new ClassPathResource("fixtures/scxa_tsne-delete.sql"),
-                new ClassPathResource("fixtures/scxa_cell_clusters-delete.sql"),
+                new ClassPathResource("fixtures/scxa_analytics-delete.sql"),
                 new ClassPathResource("fixtures/scxa_cell_group_membership-delete.sql"),
                 new ClassPathResource("fixtures/scxa_cell_group-delete.sql"),
-                new ClassPathResource("fixtures/scxa_analytics-delete.sql"));
+                new ClassPathResource("fixtures/scxa_cell_clusters-delete.sql"),
+                new ClassPathResource("fixtures/scxa_tsne-delete.sql"),
+                new ClassPathResource("fixtures/experiment-delete.sql"));
         populator.execute(dataSource);
     }
 

--- a/src/test/java/uk/ac/ebi/atlas/home/HomeControllerWIT.java
+++ b/src/test/java/uk/ac/ebi/atlas/home/HomeControllerWIT.java
@@ -20,7 +20,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @ExtendWith(SpringExtension.class)
 @WebAppConfiguration
 @ContextConfiguration(classes = TestConfig.class)
-class HomeControllerTest {
+class HomeControllerWIT {
 
     @Autowired
     private WebApplicationContext wac;

--- a/src/test/java/uk/ac/ebi/atlas/home/HomeControllerWIT.java
+++ b/src/test/java/uk/ac/ebi/atlas/home/HomeControllerWIT.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.context.web.WebAppConfiguration;
@@ -20,8 +21,15 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @ExtendWith(SpringExtension.class)
 @WebAppConfiguration
 @ContextConfiguration(classes = TestConfig.class)
+// This test is a quite the mystery: running it together with JsonExperimentsSummaryControllerWIT would make the latter
+// fail because it will re-use the DB in whatever state is in here. If we add the experiments fixture here it will pass
+// and if we don’t it will fail. Moreover, adding the fixture in JsonExperimentsSummaryControllerWIT will have no
+// effect, and trying to clean the experiment table with experiment-delete.sql here in either @AfterAll or with
+// @Sql(..., executionPhase = AFTER_TEST_METHOD) seems also not to work. For whatever reason, this test cripples the DB
+// and only @DirtiesContext solves the issue. Future Atlas developers: I hope you can explain to me what’s going on
+// here!
+@DirtiesContext
 class HomeControllerWIT {
-
     @Autowired
     private WebApplicationContext wac;
     private MockMvc mockMvc;

--- a/src/test/java/uk/ac/ebi/atlas/home/JsonExperimentsSummaryControllerWIT.java
+++ b/src/test/java/uk/ac/ebi/atlas/home/JsonExperimentsSummaryControllerWIT.java
@@ -3,8 +3,10 @@ package uk.ac.ebi.atlas.home;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.http.MediaType;
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
 import org.springframework.jdbc.datasource.init.ResourceDatabasePopulator;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
@@ -18,6 +20,7 @@ import uk.ac.ebi.atlas.configuration.TestConfig;
 import javax.inject.Inject;
 import javax.sql.DataSource;
 
+import static org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType.H2;
 import static org.springframework.test.annotation.DirtiesContext.ClassMode.BEFORE_CLASS;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -28,10 +31,20 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WebAppConfiguration
 @ContextConfiguration(classes = TestConfig.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-@DirtiesContext(classMode = BEFORE_CLASS)
 class JsonExperimentsSummaryControllerWIT {
+    @Bean
+    public DataSource dataSource2() {
+        return new EmbeddedDatabaseBuilder()
+                .generateUniqueName(true)
+                .setType(H2)
+                .setScriptEncoding("UTF-8")
+                .ignoreFailedDrops(true)
+                .addScripts("schemas/db/shared-schema.sql", "schemas/db/gxasc-schema.sql")
+                .build();
+    }
+
     @Inject
-    private DataSource dataSource;
+    private DataSource dataSource2;
 
     @Autowired
     private WebApplicationContext wac;
@@ -42,14 +55,14 @@ class JsonExperimentsSummaryControllerWIT {
     void populateDatabaseTables() {
         ResourceDatabasePopulator populator = new ResourceDatabasePopulator();
         populator.addScripts(new ClassPathResource("fixtures/experiment-fixture.sql"));
-        populator.execute(dataSource);
+        populator.execute(dataSource2);
     }
 
     @AfterAll
     void cleanDatabaseTables() {
         ResourceDatabasePopulator populator = new ResourceDatabasePopulator();
         populator.addScripts(new ClassPathResource("fixtures/experiment-delete.sql"));
-        populator.execute(dataSource);
+        populator.execute(dataSource2);
     }
 
     @BeforeEach

--- a/src/test/java/uk/ac/ebi/atlas/home/JsonExperimentsSummaryControllerWIT.java
+++ b/src/test/java/uk/ac/ebi/atlas/home/JsonExperimentsSummaryControllerWIT.java
@@ -48,6 +48,7 @@ class JsonExperimentsSummaryControllerWIT {
 
     @Autowired
     private WebApplicationContext wac;
+    private MockMvc mockMvc;
 
     private static final String ENDPOINT_URL = "/json/experiments-summary";
     @BeforeAll
@@ -57,16 +58,21 @@ class JsonExperimentsSummaryControllerWIT {
         populator.execute(dataSource2);
     }
 
-//    @AfterAll
-//    void cleanDatabaseTables() {
-//        ResourceDatabasePopulator populator = new ResourceDatabasePopulator();
-//        populator.addScripts(new ClassPathResource("fixtures/experiment-delete.sql"));
-//        populator.execute(dataSource2);
-//    }
+    @AfterAll
+    void cleanDatabaseTables() {
+        ResourceDatabasePopulator populator = new ResourceDatabasePopulator();
+        populator.addScripts(new ClassPathResource("fixtures/experiment-delete.sql"));
+        populator.execute(dataSource2);
+    }
+
+    @BeforeEach
+    void setUp() {
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(this.wac).build();
+    }
 
     @Test
     void hasLatestAndFeaturedExperiments() throws Exception {
-        var mockMvc = MockMvcBuilders.webAppContextSetup(this.wac).build();
+        System.out.println(mockMvc.perform(get(ENDPOINT_URL)).andReturn().getResponse().getContentAsString());
         mockMvc.perform(get(ENDPOINT_URL))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8))

--- a/src/test/java/uk/ac/ebi/atlas/home/JsonExperimentsSummaryControllerWIT.java
+++ b/src/test/java/uk/ac/ebi/atlas/home/JsonExperimentsSummaryControllerWIT.java
@@ -1,10 +1,6 @@
 package uk.ac.ebi.atlas.home;
 
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.ClassPathResource;
@@ -60,6 +56,7 @@ public class JsonExperimentsSummaryControllerWIT {
 
     @Test
     void hasLatestAndFeaturedExperiments() throws Exception {
+        System.out.println(mockMvc.perform(get(ENDPOINT_URL)).andReturn().getResponse().getContentAsString());
         mockMvc.perform(get(ENDPOINT_URL))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8))

--- a/src/test/java/uk/ac/ebi/atlas/home/JsonExperimentsSummaryControllerWIT.java
+++ b/src/test/java/uk/ac/ebi/atlas/home/JsonExperimentsSummaryControllerWIT.java
@@ -1,15 +1,12 @@
 package uk.ac.ebi.atlas.home;
 
-import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.Bean;
-import org.springframework.core.io.ClassPathResource;
 import org.springframework.http.MediaType;
-import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
-import org.springframework.jdbc.datasource.init.ResourceDatabasePopulator;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
@@ -17,11 +14,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 import uk.ac.ebi.atlas.configuration.TestConfig;
 
-import javax.inject.Inject;
-import javax.sql.DataSource;
-
-import static org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType.H2;
-import static org.springframework.test.annotation.DirtiesContext.ClassMode.BEFORE_CLASS;
+import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.AFTER_TEST_METHOD;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -30,40 +23,14 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @ExtendWith(SpringExtension.class)
 @WebAppConfiguration
 @ContextConfiguration(classes = TestConfig.class)
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@Sql("/fixtures/experiment-fixture.sql")
+@Sql(value = "/fixtures/experiment-delete.sql", executionPhase = AFTER_TEST_METHOD)
 class JsonExperimentsSummaryControllerWIT {
-    @Bean
-    public DataSource dataSource2() {
-        return new EmbeddedDatabaseBuilder()
-                .generateUniqueName(true)
-                .setType(H2)
-                .setScriptEncoding("UTF-8")
-                .ignoreFailedDrops(true)
-                .addScripts("schemas/db/shared-schema.sql", "schemas/db/gxasc-schema.sql")
-                .build();
-    }
-
-    @Inject
-    private DataSource dataSource2;
-
     @Autowired
     private WebApplicationContext wac;
     private MockMvc mockMvc;
 
     private static final String ENDPOINT_URL = "/json/experiments-summary";
-    @BeforeAll
-    void populateDatabaseTables() {
-        ResourceDatabasePopulator populator = new ResourceDatabasePopulator();
-        populator.addScripts(new ClassPathResource("fixtures/experiment-fixture.sql"));
-        populator.execute(dataSource2);
-    }
-
-    @AfterAll
-    void cleanDatabaseTables() {
-        ResourceDatabasePopulator populator = new ResourceDatabasePopulator();
-        populator.addScripts(new ClassPathResource("fixtures/experiment-delete.sql"));
-        populator.execute(dataSource2);
-    }
 
     @BeforeEach
     void setUp() {
@@ -72,7 +39,6 @@ class JsonExperimentsSummaryControllerWIT {
 
     @Test
     void hasLatestAndFeaturedExperiments() throws Exception {
-        System.out.println(mockMvc.perform(get(ENDPOINT_URL)).andReturn().getResponse().getContentAsString());
         mockMvc.perform(get(ENDPOINT_URL))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8))

--- a/src/test/java/uk/ac/ebi/atlas/home/JsonExperimentsSummaryControllerWIT.java
+++ b/src/test/java/uk/ac/ebi/atlas/home/JsonExperimentsSummaryControllerWIT.java
@@ -6,6 +6,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.http.MediaType;
 import org.springframework.jdbc.datasource.init.ResourceDatabasePopulator;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.context.web.WebAppConfiguration;
@@ -17,6 +18,7 @@ import uk.ac.ebi.atlas.configuration.TestConfig;
 import javax.inject.Inject;
 import javax.sql.DataSource;
 
+import static org.springframework.test.annotation.DirtiesContext.ClassMode.BEFORE_CLASS;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -26,7 +28,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WebAppConfiguration
 @ContextConfiguration(classes = TestConfig.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class JsonExperimentsSummaryControllerWIT {
+@DirtiesContext(classMode = BEFORE_CLASS)
+class JsonExperimentsSummaryControllerWIT {
     @Inject
     private DataSource dataSource;
 

--- a/src/test/java/uk/ac/ebi/atlas/home/JsonExperimentsSummaryControllerWIT.java
+++ b/src/test/java/uk/ac/ebi/atlas/home/JsonExperimentsSummaryControllerWIT.java
@@ -48,7 +48,6 @@ class JsonExperimentsSummaryControllerWIT {
 
     @Autowired
     private WebApplicationContext wac;
-    private MockMvc mockMvc;
 
     private static final String ENDPOINT_URL = "/json/experiments-summary";
     @BeforeAll
@@ -58,21 +57,16 @@ class JsonExperimentsSummaryControllerWIT {
         populator.execute(dataSource2);
     }
 
-    @AfterAll
-    void cleanDatabaseTables() {
-        ResourceDatabasePopulator populator = new ResourceDatabasePopulator();
-        populator.addScripts(new ClassPathResource("fixtures/experiment-delete.sql"));
-        populator.execute(dataSource2);
-    }
-
-    @BeforeEach
-    void setUp() {
-        this.mockMvc = MockMvcBuilders.webAppContextSetup(this.wac).build();
-    }
+//    @AfterAll
+//    void cleanDatabaseTables() {
+//        ResourceDatabasePopulator populator = new ResourceDatabasePopulator();
+//        populator.addScripts(new ClassPathResource("fixtures/experiment-delete.sql"));
+//        populator.execute(dataSource2);
+//    }
 
     @Test
     void hasLatestAndFeaturedExperiments() throws Exception {
-        System.out.println(mockMvc.perform(get(ENDPOINT_URL)).andReturn().getResponse().getContentAsString());
+        var mockMvc = MockMvcBuilders.webAppContextSetup(this.wac).build();
         mockMvc.perform(get(ENDPOINT_URL))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8))

--- a/src/test/java/uk/ac/ebi/atlas/home/JsonSpeciesSummaryControllerWIT.java
+++ b/src/test/java/uk/ac/ebi/atlas/home/JsonSpeciesSummaryControllerWIT.java
@@ -1,18 +1,12 @@
 package uk.ac.ebi.atlas.home;
 
-import com.google.common.collect.ImmutableSet;
 import com.jayway.jsonpath.JsonPath;
-import com.jayway.jsonpath.ReadContext;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.core.io.ClassPathResource;
-import org.springframework.jdbc.datasource.init.ResourceDatabasePopulator;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
@@ -23,44 +17,27 @@ import uk.ac.ebi.atlas.species.SpeciesProperties;
 import uk.ac.ebi.atlas.species.SpeciesPropertiesTrader;
 
 import javax.inject.Inject;
-import javax.sql.DataSource;
 import java.util.List;
 
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.AFTER_TEST_METHOD;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 
 @ExtendWith(SpringExtension.class)
 @WebAppConfiguration
 @ContextConfiguration(classes = TestConfig.class)
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@Sql({"/fixtures/experiment-fixture.sql"})
+@Sql(scripts = "/fixtures/experiment-delete.sql", executionPhase = AFTER_TEST_METHOD)
 class JsonSpeciesSummaryControllerWIT {
     @Inject
     private SpeciesPropertiesTrader speciesPropertiesTrader;
 
-    @Inject
-    private DataSource dataSource;
-
     @Autowired
     private WebApplicationContext wac;
-
     private MockMvc mockMvc;
 
     private static final String ENDPOINT_URL = "/json/species-summary";
-
-    @BeforeAll
-    void populateDatabaseTables() {
-        ResourceDatabasePopulator populator = new ResourceDatabasePopulator();
-        populator.addScripts(new ClassPathResource("fixtures/experiment-fixture.sql"));
-        populator.execute(dataSource);
-    }
-
-    @AfterAll
-    void cleanDatabaseTables() {
-        ResourceDatabasePopulator populator = new ResourceDatabasePopulator();
-        populator.addScripts(new ClassPathResource("fixtures/experiment-delete.sql"));
-        populator.execute(dataSource);
-    }
 
     @BeforeEach
     void setUp() {
@@ -69,20 +46,20 @@ class JsonSpeciesSummaryControllerWIT {
 
     @Test
     void responseIsWellFormed() throws Exception {
-        ImmutableSet<String> kingdoms = speciesPropertiesTrader.getAll().stream()
+        var kingdoms = speciesPropertiesTrader.getAll().stream()
                 .map(SpeciesProperties::kingdom)
                 .collect(toImmutableSet());
 
-        String json = mockMvc.perform(get(ENDPOINT_URL)).andReturn().getResponse().getContentAsString();
-        ReadContext jsonCtx = JsonPath.parse(json);
+        var json = mockMvc.perform(get(ENDPOINT_URL)).andReturn().getResponse().getContentAsString();
+        var jsonCtx = JsonPath.parse(json);
 
-        List<String> jsonKingdoms = jsonCtx.read("$.speciesSummary[*].kingdom");
+        var jsonKingdoms = jsonCtx.<List<String>>read("$.speciesSummary[*].kingdom");
         assertThat(jsonKingdoms).containsAnyElementsOf(kingdoms);
 
-        List<String> jsonCardTypes = jsonCtx.read("$.speciesSummary[*].cards[*].iconType");
+        var jsonCardTypes = jsonCtx.<List<String>>read("$.speciesSummary[*].cards[*].iconType");
         assertThat(jsonCardTypes).containsAnyOf("species");
 
-        List<String> jsonCardSources = jsonCtx.read("$.speciesSummary[*].cards[*].iconSrc");
+        var jsonCardSources = jsonCtx.<List<String>>read("$.speciesSummary[*].cards[*].iconSrc");
         assertThat(jsonCardSources)
                 .allMatch(iconSrc -> speciesPropertiesTrader.get(iconSrc) != SpeciesProperties.UNKNOWN);
     }

--- a/src/test/java/uk/ac/ebi/atlas/search/GeneSearchDaoIT.java
+++ b/src/test/java/uk/ac/ebi/atlas/search/GeneSearchDaoIT.java
@@ -70,11 +70,11 @@ class GeneSearchDaoIT {
     void cleanDatabaseTables() {
         var populator = new ResourceDatabasePopulator();
         populator.addScripts(
-                new ClassPathResource("fixtures/experiment-delete.sql"),
-                new ClassPathResource("fixtures/scxa_analytics-delete.sql"),
-                new ClassPathResource("fixtures/scxa_cell_group-delete.sql"),
+                new ClassPathResource("fixtures/scxa_cell_group_marker_genes-delete.sql"),
                 new ClassPathResource("fixtures/scxa_cell_group_membership-delete.sql"),
-                new ClassPathResource("fixtures/scxa_cell_group_marker_gene_stats-delete.sql"));
+                new ClassPathResource("fixtures/scxa_cell_group-delete.sql"),
+                new ClassPathResource("fixtures/scxa_analytics-delete.sql"),
+                new ClassPathResource("fixtures/experiment-delete.sql"));
         populator.execute(dataSource);
     }
 

--- a/src/test/java/uk/ac/ebi/atlas/search/JsonBioentityInformationControllerWIT.java
+++ b/src/test/java/uk/ac/ebi/atlas/search/JsonBioentityInformationControllerWIT.java
@@ -51,7 +51,7 @@ class JsonBioentityInformationControllerWIT {
 
     private MockMvc mockMvc;
 
-    private static final String urlTemplate = "/json/bioentity-information/{geneId}";
+    private static final String URL_TEMPLATE = "/json/bioentity-information/{geneId}";
 
     @BeforeAll
     void populateDatabaseTables() {
@@ -77,7 +77,7 @@ class JsonBioentityInformationControllerWIT {
         String geneId = jdbcTestUtils.fetchRandomGene();
 
         this.mockMvc
-                .perform(get(urlTemplate, geneId))
+                .perform(get(URL_TEMPLATE, geneId))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8))
                 .andExpect(jsonPath("$.bioentityProperties[0].type", isA(String.class)))
@@ -94,7 +94,7 @@ class JsonBioentityInformationControllerWIT {
 
         if(!geneId.isEmpty()) {
             this.mockMvc
-                    .perform(get(urlTemplate, geneId))
+                    .perform(get(URL_TEMPLATE, geneId))
                     .andExpect(status().isOk())
                     .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8));
         }
@@ -103,7 +103,7 @@ class JsonBioentityInformationControllerWIT {
     @Test
     void geneNotFound() throws Exception {
         this.mockMvc
-                .perform(get(urlTemplate, "unknown"))
+                .perform(get(URL_TEMPLATE, "unknown"))
                 .andExpect(status().isNotFound());
     }
 
@@ -112,7 +112,7 @@ class JsonBioentityInformationControllerWIT {
         String geneId = jdbcTestUtils.fetchRandomGene();
 
         this.mockMvc
-                .perform(get(urlTemplate, geneId))
+                .perform(get(URL_TEMPLATE, geneId))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8))
                 .andExpect(jsonPath("$.bioentityProperties[-1:].type", contains("expression_atlas")))


### PR DESCRIPTION
Companion PR of https://github.com/ebi-gene-expression-group/atlas-web-core/pull/59 and https://github.com/ebi-gene-expression-group/atlas-web-core/pull/60.

This is basically some code reorganisation as a change in a couple of classes that were promoted to Spring beans, which meant thtat there need to be implementation candidates in the project or we’ll have compilation errors. However, this hasn’t been a smooth path since I encountered a very weird test interaction between `HomeControllerWIT` and `JsonExperimentsSummaryControllerWIT`. Which took me on an unexepcted road in `atlas-web-core` to refactor code here and there so that we have fewer tests that depend on `bulk-analytics` or `gene2experiment` collections. Since we now run SolrCloud on Docker Compose and one of those two collections might not be present, here’s an effort to go towards a truly generic `atlas-web-core` project. Some of the code here are implementations of interfaces added there and some better ways to run tests.