### PR TITLE
Hotfix/176864720 hide experiment for incomplete anatomogram

### DIFF
--- a/src/main/java/uk/ac/ebi/atlas/experimentpage/tabs/ExperimentPageContentService.java
+++ b/src/main/java/uk/ac/ebi/atlas/experimentpage/tabs/ExperimentPageContentService.java
@@ -43,7 +43,8 @@ public class ExperimentPageContentService {
             "E-CURD-11",
             "E-MTAB-6308",
             "E-HCAD-10",
-            "E-CURD-10"
+            "E-CURD-10",
+			"E-GEOD-114530"
     );
 
     public ExperimentPageContentService(ExperimentFileLocationService experimentFileLocationService,

--- a/src/main/java/uk/ac/ebi/atlas/experimentpage/tabs/ExperimentPageContentService.java
+++ b/src/main/java/uk/ac/ebi/atlas/experimentpage/tabs/ExperimentPageContentService.java
@@ -36,16 +36,8 @@ public class ExperimentPageContentService {
     private final ExperimentTrader experimentTrader;
 
     final static ImmutableSet<String> EXPERIMENTS_WITH_NO_ANATOMOGRAM = ImmutableSet.of(
-            "E-GEOD-130473",
-            "E-HCAD-8",
-            "E-MTAB-6653",
-            "E-GEOD-86618",
-            "E-CURD-11",
-            "E-MTAB-6308",
-            "E-HCAD-10",
-            "E-CURD-10",
-			"E-GEOD-114530"
-    );
+            "E-GEOD-130473", "E-HCAD-8", "E-MTAB-6653", "E-GEOD-86618", "E-CURD-11", "E-MTAB-6308",
+            "E-HCAD-10", "E-CURD-10", "E-GEOD-114530");
 
     public ExperimentPageContentService(ExperimentFileLocationService experimentFileLocationService,
                                         DataFileHub dataFileHub,


### PR DESCRIPTION
Simple PR to hide an experiment: `E-GEOD-114530` from anatomograms view.