### PR TITLE
Bugfix #177533187 – Log an error if a metadata value is missing

### DIFF
--- a/app/src/main/java/uk/ac/ebi/atlas/experimentpage/metadata/CellMetadataDao.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/experimentpage/metadata/CellMetadataDao.java
@@ -178,7 +178,7 @@ public class CellMetadataDao {
                             // https://www.pivotaltracker.com/story/show/177533187
                             tuple -> {
                                 if (tuple.getStrings(METADATA_VALUE_TARGET_FIELD_NAME) == null ||
-                                    !tuple.getStrings(METADATA_VALUE_TARGET_FIELD_NAME).isEmpty()) {
+                                    tuple.getStrings(METADATA_VALUE_TARGET_FIELD_NAME).isEmpty()) {
                                     LOGGER.error(
                                             "Missing metadata value for {} – {}",
                                             tuple.getString(CELL_ID.name()),


### PR DESCRIPTION
Rather than showing a cryptic 400 error we use the placeholder “Not available” for missing metadata values. I haven’t included a test because:
- We need to use an incorrect condensed SDRF file
- Verifying that the logger adds an error message would mean a mocked logger, a spy, or a somewhat convoluted constructor just for the sake of testing

In summary: testing a side effect as a consequence of an edge case doesn’t seem like the most solid business logic and should happen rarely.