### PR TITLE
Feature/178928604 enable access for private experiments rebase

### DIFF
--- a/app/src/main/java/uk/ac/ebi/atlas/configuration/CacheConfig.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/configuration/CacheConfig.java
@@ -42,6 +42,7 @@ public class CacheConfig {
 
                 builder -> builder.name("hcaMetadata"),
                 builder -> builder.name("inferredCellTypesOntology"),
-                builder -> builder.name("inferredCellTypesAuthors"));
+                builder -> builder.name("inferredCellTypesAuthors"),
+                builder -> builder.name("experimentAccessions"));
     }
 }

--- a/app/src/main/java/uk/ac/ebi/atlas/configuration/CacheConfig.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/configuration/CacheConfig.java
@@ -43,6 +43,6 @@ public class CacheConfig {
                 builder -> builder.name("hcaMetadata"),
                 builder -> builder.name("inferredCellTypesOntology"),
                 builder -> builder.name("inferredCellTypesAuthors"),
-                builder -> builder.name("experimentAccessions"));
+                builder -> builder.name("privateExperimentAccessions"));
     }
 }

--- a/app/src/main/java/uk/ac/ebi/atlas/experimentimport/ScxaExperimentCrud.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/experimentimport/ScxaExperimentCrud.java
@@ -45,7 +45,8 @@ public class ScxaExperimentCrud extends ExperimentCrud {
             @CacheEvict(cacheNames = "jsonCellMetadata", allEntries = true),
             @CacheEvict(cacheNames = "jsonTSnePlotWithClusters", allEntries = true),
             @CacheEvict(cacheNames = "jsonTSnePlotWithMetadata", allEntries = true),
-            @CacheEvict(cacheNames = "jsonExperimentsList", allEntries = true) })
+            @CacheEvict(cacheNames = "jsonExperimentsList", allEntries = true),
+            @CacheEvict(cacheNames = "privateExperimentAccessions", allEntries = true)})
     public UUID createExperiment(String experimentAccession, boolean isPrivate) {
         var condensedSdrfParserOutput =
                 condensedSdrfParser.parse(experimentAccession, SINGLE_CELL_RNASEQ_MRNA_BASELINE);
@@ -82,7 +83,8 @@ public class ScxaExperimentCrud extends ExperimentCrud {
             @CacheEvict(cacheNames = "plotOptions", key = "#experimentAccession"),
             @CacheEvict(cacheNames = "jsonCellMetadata", allEntries = true),
             @CacheEvict(cacheNames = "jsonTSnePlotWithMetadata", allEntries = true),
-            @CacheEvict(cacheNames = "jsonExperimentsList", allEntries = true) })
+            @CacheEvict(cacheNames = "jsonExperimentsList", allEntries = true),
+            @CacheEvict(cacheNames = "privateExperimentAccessions", allEntries = true)})
     public void updateExperimentDesign(String experimentAccession) {
         var experimentDto =
                 readExperiment(experimentAccession)
@@ -110,7 +112,8 @@ public class ScxaExperimentCrud extends ExperimentCrud {
             @CacheEvict(cacheNames = "jsonTSnePlotWithClusters", allEntries = true),
             @CacheEvict(cacheNames = "jsonTSnePlotWithMetadata", allEntries = true),
             @CacheEvict(cacheNames = "experiment2Collections", key = "#experimentAccession"),
-            @CacheEvict(cacheNames = "jsonExperimentsList", allEntries = true) })
+            @CacheEvict(cacheNames = "jsonExperimentsList", allEntries = true),
+            @CacheEvict(cacheNames = "privateExperimentAccessions", allEntries = true)})
     public void deleteExperiment(String experimentAccession) {
         super.deleteExperiment(experimentAccession);
     }
@@ -129,7 +132,8 @@ public class ScxaExperimentCrud extends ExperimentCrud {
             @CacheEvict(cacheNames = "jsonCellMetadata", allEntries = true),
             @CacheEvict(cacheNames = "jsonTSnePlotWithClusters", allEntries = true),
             @CacheEvict(cacheNames = "jsonTSnePlotWithMetadata", allEntries = true),
-            @CacheEvict(cacheNames = "jsonExperimentsList", allEntries = true) })
+            @CacheEvict(cacheNames = "jsonExperimentsList", allEntries = true),
+            @CacheEvict(cacheNames = "privateExperimentAccessions", allEntries = true)})
     public void updateExperimentPrivate(String experimentAccession, boolean isPrivate) {
         super.updateExperimentPrivate(experimentAccession, isPrivate);
     }

--- a/app/src/main/java/uk/ac/ebi/atlas/experimentimport/admin/SingleCellExperimentAdminController.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/experimentimport/admin/SingleCellExperimentAdminController.java
@@ -1,7 +1,10 @@
 package uk.ac.ebi.atlas.experimentimport.admin;
 
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Caching;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import uk.ac.ebi.atlas.experimentimport.ScxaExperimentCrud;
 import uk.ac.ebi.atlas.resource.DataFileHub;
@@ -16,5 +19,12 @@ public class SingleCellExperimentAdminController extends ExperimentAdminControll
                 new ExperimentOps(
                         new ExperimentOpLogWriter(dataFileHub),
                         new SingleCellOpsExecutionService(scxaExperimentCrud)));
+    }
+
+    @Caching(evict = {
+            @CacheEvict(cacheNames = "experimentAccessions", allEntries = true)})
+    @GetMapping(value = "/json/experiments/private/experimentAccessions/clearCache")
+    public String fooBar() {
+        return "";
     }
 }

--- a/app/src/main/java/uk/ac/ebi/atlas/experimentimport/admin/SingleCellExperimentAdminController.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/experimentimport/admin/SingleCellExperimentAdminController.java
@@ -22,7 +22,7 @@ public class SingleCellExperimentAdminController extends ExperimentAdminControll
     }
 
     @Caching(evict = {
-            @CacheEvict(cacheNames = "experimentAccessions", allEntries = true)})
+            @CacheEvict(cacheNames = "privateExperimentAccessions", allEntries = true)})
     @GetMapping(value = "/json/experiments/private/experimentAccessions/clearCache")
     public String fooBar() {
         return "";

--- a/app/src/main/java/uk/ac/ebi/atlas/experimentimport/admin/SingleCellExperimentAdminController.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/experimentimport/admin/SingleCellExperimentAdminController.java
@@ -23,7 +23,7 @@ public class SingleCellExperimentAdminController extends ExperimentAdminControll
 
     @Caching(evict = {
             @CacheEvict(cacheNames = "privateExperimentAccessions", allEntries = true)})
-    @GetMapping(value = "/json/experiments/private/experimentAccessions/clearCache")
+    @GetMapping(value = "/private/experiments/cache/clear")
     public String fooBar() {
         return "";
     }

--- a/app/src/main/java/uk/ac/ebi/atlas/experimentpage/tabs/ExperimentPageContentService.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/experimentpage/tabs/ExperimentPageContentService.java
@@ -107,7 +107,7 @@ public class ExperimentPageContentService {
 
     public JsonArray getDownloads(String experimentAccession, String accessKey) {
         var result = new JsonArray();
-        var experiment = experimentTrader.getPublicExperiment(experimentAccession);
+        var experiment = experimentTrader.getExperiment(experimentAccession, accessKey);
         var technologyType = experiment.getTechnologyType();
 
         var metadataFiles =

--- a/app/src/main/java/uk/ac/ebi/atlas/search/geneids/GeneIdSearchDao.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/search/geneids/GeneIdSearchDao.java
@@ -12,6 +12,7 @@ import uk.ac.ebi.atlas.solr.cloud.collections.Gene2ExperimentCollectionProxy;
 import uk.ac.ebi.atlas.solr.cloud.search.SolrQueryBuilder;
 import uk.ac.ebi.atlas.solr.cloud.search.streamingexpressions.decorator.IntersectStreamBuilder;
 import uk.ac.ebi.atlas.solr.cloud.search.streamingexpressions.source.SearchStreamBuilder;
+import uk.ac.ebi.atlas.trader.ExperimentTraderDao;
 
 import java.util.Optional;
 
@@ -28,10 +29,13 @@ public class GeneIdSearchDao {
 
     private final BioentitiesCollectionProxy bioentitiesCollectionProxy;
     private final Gene2ExperimentCollectionProxy gene2ExperimentCollectionProxy;
+    private final ExperimentTraderDao experimentTraderDao;
 
-    public GeneIdSearchDao(SolrCloudCollectionProxyFactory collectionProxyFactory) {
+    public GeneIdSearchDao(SolrCloudCollectionProxyFactory collectionProxyFactory,
+                           ExperimentTraderDao experimentTraderDao) {
         bioentitiesCollectionProxy = collectionProxyFactory.create(BioentitiesCollectionProxy.class);
         gene2ExperimentCollectionProxy = collectionProxyFactory.create(Gene2ExperimentCollectionProxy.class);
+        this.experimentTraderDao = experimentTraderDao;
     }
 
     // This is one of the edge cases where an empty optional is semantically different than an empty collection. The
@@ -57,7 +61,6 @@ public class GeneIdSearchDao {
                         .addQueryFieldByTerm(PROPERTY_NAME, propertyName)
                         .setFieldList(BioentitiesCollectionProxy.BIOENTITY_IDENTIFIER)
                         .sortBy(BioentitiesCollectionProxy.BIOENTITY_IDENTIFIER, SolrQuery.ORDER.asc);
-
         return searchInTwoSteps(bioentitiesQueryBuilder);
     }
 
@@ -82,9 +85,10 @@ public class GeneIdSearchDao {
     // A set since we don’t care about the order, we might want a list if results are ranked somehow
     private ImmutableSet<String> searchWithinGeneIdsExpressedInExperiments(
             SolrQueryBuilder<BioentitiesCollectionProxy> bioentitiesQueryBuilder) {
-
         var g2eQueryBuilder =
                 new SolrQueryBuilder<Gene2ExperimentCollectionProxy>()
+                        .addNegativeFilterFieldByTerm(Gene2ExperimentCollectionProxy.EXPERIMENT_ACCESSION,
+                                experimentTraderDao.fetchPrivateExperimentAccessions())
                         .setFieldList(Gene2ExperimentCollectionProxy.BIOENTITY_IDENTIFIER)
                         .sortBy(Gene2ExperimentCollectionProxy.BIOENTITY_IDENTIFIER, SolrQuery.ORDER.asc)
                         .setRows(SOLR_MAX_ROWS);

--- a/app/src/main/javascript/bundles/experiment-page/src/TSnePlotViewRoute.js
+++ b/app/src/main/javascript/bundles/experiment-page/src/TSnePlotViewRoute.js
@@ -60,7 +60,7 @@ class TSnePlotViewRoute extends React.Component {
   render() {
     const { location, match, history } = this.props
     const { atlasUrl, suggesterEndpoint, initialCellTypeValues } = this.props
-    const { species, experimentAccession, ks, ksWithMarkerGenes, plotTypesAndOptions, metadata, anatomogram } = this.props
+    const { species, experimentAccession, accessKey, ks, ksWithMarkerGenes, plotTypesAndOptions, metadata, anatomogram } = this.props
     const search = URI(location.search).search(true)
 
       const plotTypeDropdown =  [
@@ -95,6 +95,7 @@ class TSnePlotViewRoute extends React.Component {
           expressionPlotClassName={`small-12 large-6 columns`}
           speciesName={species}
           experimentAccession={experimentAccession}
+          accessKey={accessKey}
           selectedPlotOption={search.plotOption || this.state.selectedPlotOption}
           selectedPlotType={search.plotType || this.state.selectedPlotType}
           ks={ks}
@@ -301,6 +302,7 @@ TSnePlotViewRoute.propTypes = {
   atlasUrl: PropTypes.string.isRequired,
   resourcesUrl: PropTypes.string,
   experimentAccession: PropTypes.string.isRequired,
+  accessKey: PropTypes.string,
   ks: PropTypes.arrayOf(PropTypes.number).isRequired,
   ksWithMarkerGenes: PropTypes.arrayOf(PropTypes.number).isRequired,
   suggesterEndpoint: PropTypes.string.isRequired,

--- a/app/src/test/java/uk/ac/ebi/atlas/download/ExperimentFileLocationServiceIT.java
+++ b/app/src/test/java/uk/ac/ebi/atlas/download/ExperimentFileLocationServiceIT.java
@@ -267,8 +267,8 @@ class ExperimentFileLocationServiceIT {
 				.map(entry -> isArchive ? experimentAccession + "/" + entry : entry)
 				.collect(Collectors.toList());
 
-		assertThat(expectedFileNames)
-				.isNotEmpty()
-				.containsAnyElementsOf(fileNames);
+//		assertThat(expectedFileNames)
+//				.isNotEmpty()
+//				.containsAnyElementsOf(fileNames);
 	}
 }

--- a/app/src/test/java/uk/ac/ebi/atlas/download/ExperimentFileLocationServiceIT.java
+++ b/app/src/test/java/uk/ac/ebi/atlas/download/ExperimentFileLocationServiceIT.java
@@ -18,7 +18,6 @@ import uk.ac.ebi.atlas.testutils.JdbcUtils;
 import javax.inject.Inject;
 import javax.sql.DataSource;
 import java.io.File;
-import java.net.URI;
 import java.nio.file.Path;
 import java.text.MessageFormat;
 import java.util.List;
@@ -267,8 +266,8 @@ class ExperimentFileLocationServiceIT {
 				.map(entry -> isArchive ? experimentAccession + "/" + entry : entry)
 				.collect(Collectors.toList());
 
-//		assertThat(expectedFileNames)
-//				.isNotEmpty()
-//				.containsAnyElementsOf(fileNames);
+		assertThat(expectedFileNames)
+				.isNotEmpty()
+				.containsAnyElementsOf(fileNames);
 	}
 }

--- a/app/src/test/java/uk/ac/ebi/atlas/experimentpage/cellplot/JsonCellPlotControllerWIT.java
+++ b/app/src/test/java/uk/ac/ebi/atlas/experimentpage/cellplot/JsonCellPlotControllerWIT.java
@@ -1,0 +1,119 @@
+package uk.ac.ebi.atlas.experimentpage.cellplot;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.datasource.init.ResourceDatabasePopulator;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import uk.ac.ebi.atlas.configuration.TestConfig;
+import uk.ac.ebi.atlas.experimentimport.ExperimentCrud;
+import uk.ac.ebi.atlas.experimentpage.tsneplot.TSnePlotSettingsService;
+import uk.ac.ebi.atlas.testutils.JdbcUtils;
+import uk.ac.ebi.atlas.trader.ExperimentTrader;
+
+import javax.inject.Inject;
+import javax.sql.DataSource;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(SpringExtension.class)
+@WebAppConfiguration
+@ContextConfiguration(classes = TestConfig.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class JsonCellPlotControllerWIT {
+
+    @Inject
+    private DataSource dataSource;
+
+    @Inject
+    private ExperimentTrader experimentTrader;
+
+    @Inject
+    private JdbcUtils jdbcUtils;
+
+    @Inject
+    private ExperimentCrud experimentCrud;
+
+    @Inject
+    private TSnePlotSettingsService tSnePlotSettingsService;
+
+    @Autowired
+    private WebApplicationContext wac;
+
+    private MockMvc mockMvc;
+
+    private String accessKey;
+
+    private String endpoint_url;
+
+
+    ResourceDatabasePopulator populator = new ResourceDatabasePopulator();
+
+    @BeforeAll
+    void populateDatabaseTables() {
+        populator.setScripts(
+                new ClassPathResource("fixtures/202108/experiment.sql"),
+                new ClassPathResource("fixtures/202108/scxa_analytics.sql"),
+                new ClassPathResource("fixtures/202108/scxa_coords.sql"),
+                new ClassPathResource("fixtures/202108/scxa_cell_group.sql"),
+                new ClassPathResource("fixtures/202108/scxa_cell_group_membership.sql"));
+        populator.execute(dataSource);
+    }
+
+    @AfterAll
+    void cleanDatabaseTables() {
+        populator.setScripts(
+                new ClassPathResource("fixtures/202108/scxa_cell_group_marker_gene_stats-delete.sql"),
+                new ClassPathResource("fixtures/202108/scxa_cell_group_marker_genes-delete.sql"),
+                new ClassPathResource("fixtures/202108/scxa_cell_group_membership-delete.sql"),
+                new ClassPathResource("fixtures/202108/scxa_cell_group-delete.sql"),
+                new ClassPathResource("fixtures/202108/scxa_coords-delete.sql"),
+                new ClassPathResource("fixtures/202108/scxa_analytics-delete.sql"),
+                new ClassPathResource("fixtures/202108/experiment-delete.sql"));
+        populator.execute(dataSource);
+    }
+
+    @BeforeEach
+    void setUp() {
+        var experimentAccession = jdbcUtils.fetchRandomPublicExperimentAccession();
+        var experiment = experimentTrader.getPublicExperiment(experimentAccession);
+
+        experimentCrud.updateExperimentPrivate(experimentAccession, true);
+        accessKey = experiment.getAccessKey();
+
+        var k = tSnePlotSettingsService.getExpectedClusters(experimentAccession);
+        endpoint_url = "/json/cell-plots/" + experimentAccession + "/clusters/k/" + k.get();
+
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(this.wac).build();
+
+    }
+
+    @Test
+    void returnsPrivateExperimentWithValidAccessKey() throws Exception {
+        mockMvc.perform(get(endpoint_url + "?accessKey=" + accessKey + "&n_neighbors=5"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8))
+                .andExpect(jsonPath("$.series").isArray())
+                .andExpect(jsonPath("$.series").isNotEmpty());
+    }
+
+    @Test
+    void returnsErrorWithInValidAccessKey() throws Exception {
+        mockMvc.perform(get(endpoint_url + "?accessKey=foo_bar&n_neighbors=5"))
+                .andExpect(status().isBadRequest());
+    }
+}

--- a/app/src/test/java/uk/ac/ebi/atlas/experimentpage/cellplot/JsonCellPlotControllerWIT.java
+++ b/app/src/test/java/uk/ac/ebi/atlas/experimentpage/cellplot/JsonCellPlotControllerWIT.java
@@ -17,10 +17,8 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 import uk.ac.ebi.atlas.configuration.TestConfig;
-import uk.ac.ebi.atlas.experimentimport.ExperimentCrud;
 import uk.ac.ebi.atlas.experimentpage.tsneplot.TSnePlotSettingsService;
 import uk.ac.ebi.atlas.testutils.JdbcUtils;
-import uk.ac.ebi.atlas.trader.ExperimentTrader;
 
 import javax.inject.Inject;
 import javax.sql.DataSource;

--- a/app/src/test/java/uk/ac/ebi/atlas/experimentpage/cellplot/JsonCellPlotControllerWIT.java
+++ b/app/src/test/java/uk/ac/ebi/atlas/experimentpage/cellplot/JsonCellPlotControllerWIT.java
@@ -40,13 +40,7 @@ class JsonCellPlotControllerWIT {
     private DataSource dataSource;
 
     @Inject
-    private ExperimentTrader experimentTrader;
-
-    @Inject
     private JdbcUtils jdbcUtils;
-
-    @Inject
-    private ExperimentCrud experimentCrud;
 
     @Inject
     private TSnePlotSettingsService tSnePlotSettingsService;
@@ -90,10 +84,8 @@ class JsonCellPlotControllerWIT {
     @BeforeEach
     void setUp() {
         var experimentAccession = jdbcUtils.fetchRandomPublicExperimentAccession();
-        var experiment = experimentTrader.getPublicExperiment(experimentAccession);
-
-        experimentCrud.updateExperimentPrivate(experimentAccession, true);
-        accessKey = experiment.getAccessKey();
+        jdbcUtils.updatePublicExperimentAccessionToPrivate(experimentAccession);
+        accessKey = jdbcUtils.fetchExperimentAccessKey(experimentAccession);
 
         var k = tSnePlotSettingsService.getExpectedClusters(experimentAccession);
         endpoint_url = "/json/cell-plots/" + experimentAccession + "/clusters/k/" + k.get();

--- a/app/src/test/java/uk/ac/ebi/atlas/experimentpage/tabs/ExperimentPageContentServiceIT.java
+++ b/app/src/test/java/uk/ac/ebi/atlas/experimentpage/tabs/ExperimentPageContentServiceIT.java
@@ -159,41 +159,40 @@ import static org.assertj.core.api.Assertions.assertThat;
         }
     }
 
-//    @Test
-//    @Ignore
-//    void getValidTsnePlotDataJson() {
-//        var experimentAccession = jdbcTestUtils.fetchRandomExperimentAccession();
-//        var result = this.subject.getTsnePlotData(experimentAccession);
-//
-//        assertThat(result.has("suggesterEndpoint")).isTrue();
-//        assertThat(result.get("suggesterEndpoint").getAsString()).isEqualToIgnoringCase("json/suggestions");
-//
-//        assertThat(result.has("ks")).isTrue();
-//        assertThat(
-//                ImmutableSet.copyOf(result.get("ks").getAsJsonArray()).stream()
-//                        .map(JsonElement::getAsInt)
-//                        .collect(toSet()))
-//                .containsExactlyInAnyOrder(
-//                        jdbcTestUtils.fetchKsFromCellGroups(experimentAccession).toArray(new Integer[0]));
-//
-//        if (result.has("selectedK")) {
-//            assertThat(jdbcTestUtils.fetchKsFromCellGroups(experimentAccession))
-//                    .contains(result.get("selectedK").getAsInt());
-//        }
-//
-//        assertThat(result.has("plotTypesAndOptions")).isTrue();
-//        assertThat(result.get("plotTypesAndOptions").getAsJsonObject().get("tsne").getAsJsonArray()).isNotEmpty();
-//        assertThat(result.get("plotTypesAndOptions").getAsJsonObject().get("umap").getAsJsonArray()).isNotEmpty();
-//
-//        // Not all experiments have metadata, see E-GEOD-99058
-//        if (result.has("metadata")) {
-//            assertThat(result.get("metadata").getAsJsonArray())
-//                    .doesNotHaveDuplicates();
-//        }
-//
-//        assertThat(result.has("units")).isTrue();
-//        assertThat(result.get("units").getAsJsonArray()).isNotEmpty();
-//    }
+    @Test
+    void getValidTsnePlotDataJson() {
+        var experimentAccession = jdbcTestUtils.fetchRandomExperimentAccession();
+        var result = this.subject.getTsnePlotData(experimentAccession);
+
+        assertThat(result.has("suggesterEndpoint")).isTrue();
+        assertThat(result.get("suggesterEndpoint").getAsString()).isEqualToIgnoringCase("json/suggestions");
+
+        assertThat(result.has("ks")).isTrue();
+        assertThat(
+                ImmutableSet.copyOf(result.get("ks").getAsJsonArray()).stream()
+                        .map(JsonElement::getAsInt)
+                        .collect(toSet()))
+                .containsExactlyInAnyOrder(
+                        jdbcTestUtils.fetchKsFromCellGroups(experimentAccession).toArray(new Integer[0]));
+
+        if (result.has("selectedK")) {
+            assertThat(jdbcTestUtils.fetchKsFromCellGroups(experimentAccession))
+                    .contains(result.get("selectedK").getAsInt());
+        }
+
+        assertThat(result.has("plotTypesAndOptions")).isTrue();
+        assertThat(result.get("plotTypesAndOptions").getAsJsonObject().get("tsne").getAsJsonArray()).isNotEmpty();
+        assertThat(result.get("plotTypesAndOptions").getAsJsonObject().get("umap").getAsJsonArray()).isNotEmpty();
+
+        // Not all experiments have metadata, see E-GEOD-99058
+        if (result.has("metadata")) {
+            assertThat(result.get("metadata").getAsJsonArray())
+                    .doesNotHaveDuplicates();
+        }
+
+        assertThat(result.has("units")).isTrue();
+        assertThat(result.get("units").getAsJsonArray()).isNotEmpty();
+    }
 
     @Test
     void anatomogramExistsForValidExperiment() {

--- a/app/src/test/java/uk/ac/ebi/atlas/experimentpage/tabs/ExperimentPageContentServiceIT.java
+++ b/app/src/test/java/uk/ac/ebi/atlas/experimentpage/tabs/ExperimentPageContentServiceIT.java
@@ -35,7 +35,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @WebAppConfiguration
 @ContextConfiguration(classes = TestConfig.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-    class ExperimentPageContentServiceIT {
+class ExperimentPageContentServiceIT {
     @Inject
     private DataSource dataSource;
 

--- a/app/src/test/java/uk/ac/ebi/atlas/experimentpage/tabs/ExperimentPageContentServiceIT.java
+++ b/app/src/test/java/uk/ac/ebi/atlas/experimentpage/tabs/ExperimentPageContentServiceIT.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
+import org.junit.Ignore;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -34,7 +35,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @WebAppConfiguration
 @ContextConfiguration(classes = TestConfig.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-class ExperimentPageContentServiceIT {
+    class ExperimentPageContentServiceIT {
     @Inject
     private DataSource dataSource;
 
@@ -158,40 +159,41 @@ class ExperimentPageContentServiceIT {
         }
     }
 
-    @Test
-    void getValidTsnePlotDataJson() {
-        var experimentAccession = jdbcTestUtils.fetchRandomExperimentAccession();
-        var result = this.subject.getTsnePlotData(experimentAccession);
-
-        assertThat(result.has("suggesterEndpoint")).isTrue();
-        assertThat(result.get("suggesterEndpoint").getAsString()).isEqualToIgnoringCase("json/suggestions");
-
-        assertThat(result.has("ks")).isTrue();
-        assertThat(
-                ImmutableSet.copyOf(result.get("ks").getAsJsonArray()).stream()
-                        .map(JsonElement::getAsInt)
-                        .collect(toSet()))
-                .containsExactlyInAnyOrder(
-                        jdbcTestUtils.fetchKsFromCellGroups(experimentAccession).toArray(new Integer[0]));
-
-        if (result.has("selectedK")) {
-            assertThat(jdbcTestUtils.fetchKsFromCellGroups(experimentAccession))
-                    .contains(result.get("selectedK").getAsInt());
-        }
-
-        assertThat(result.has("plotTypesAndOptions")).isTrue();
-        assertThat(result.get("plotTypesAndOptions").getAsJsonObject().get("tsne").getAsJsonArray()).isNotEmpty();
-        assertThat(result.get("plotTypesAndOptions").getAsJsonObject().get("umap").getAsJsonArray()).isNotEmpty();
-
-        // Not all experiments have metadata, see E-GEOD-99058
-        if (result.has("metadata")) {
-            assertThat(result.get("metadata").getAsJsonArray())
-                    .doesNotHaveDuplicates();
-        }
-
-        assertThat(result.has("units")).isTrue();
-        assertThat(result.get("units").getAsJsonArray()).isNotEmpty();
-    }
+//    @Test
+//    @Ignore
+//    void getValidTsnePlotDataJson() {
+//        var experimentAccession = jdbcTestUtils.fetchRandomExperimentAccession();
+//        var result = this.subject.getTsnePlotData(experimentAccession);
+//
+//        assertThat(result.has("suggesterEndpoint")).isTrue();
+//        assertThat(result.get("suggesterEndpoint").getAsString()).isEqualToIgnoringCase("json/suggestions");
+//
+//        assertThat(result.has("ks")).isTrue();
+//        assertThat(
+//                ImmutableSet.copyOf(result.get("ks").getAsJsonArray()).stream()
+//                        .map(JsonElement::getAsInt)
+//                        .collect(toSet()))
+//                .containsExactlyInAnyOrder(
+//                        jdbcTestUtils.fetchKsFromCellGroups(experimentAccession).toArray(new Integer[0]));
+//
+//        if (result.has("selectedK")) {
+//            assertThat(jdbcTestUtils.fetchKsFromCellGroups(experimentAccession))
+//                    .contains(result.get("selectedK").getAsInt());
+//        }
+//
+//        assertThat(result.has("plotTypesAndOptions")).isTrue();
+//        assertThat(result.get("plotTypesAndOptions").getAsJsonObject().get("tsne").getAsJsonArray()).isNotEmpty();
+//        assertThat(result.get("plotTypesAndOptions").getAsJsonObject().get("umap").getAsJsonArray()).isNotEmpty();
+//
+//        // Not all experiments have metadata, see E-GEOD-99058
+//        if (result.has("metadata")) {
+//            assertThat(result.get("metadata").getAsJsonArray())
+//                    .doesNotHaveDuplicates();
+//        }
+//
+//        assertThat(result.has("units")).isTrue();
+//        assertThat(result.get("units").getAsJsonArray()).isNotEmpty();
+//    }
 
     @Test
     void anatomogramExistsForValidExperiment() {

--- a/app/src/test/java/uk/ac/ebi/atlas/experimentpage/tabs/ExperimentPageContentServiceTest.java
+++ b/app/src/test/java/uk/ac/ebi/atlas/experimentpage/tabs/ExperimentPageContentServiceTest.java
@@ -144,7 +144,7 @@ class ExperimentPageContentServiceTest {
                 .withTechnologyType(ImmutableList.of("Smart-Seq", "10xV1"))
                 .build();
 
-        when(experimentTraderMock.getPublicExperiment(EXPERIMENT_ACCESSION)).thenReturn(experiment);
+        when(experimentTraderMock.getExperiment(EXPERIMENT_ACCESSION,"")).thenReturn(experiment);
 
         var result = subject.getDownloads(EXPERIMENT_ACCESSION, "");
         assertThat(result)
@@ -167,7 +167,7 @@ class ExperimentPageContentServiceTest {
                 .withTechnologyType(ImmutableList.of("10xV1"))
                 .build();
 
-        when(experimentTraderMock.getPublicExperiment(EXPERIMENT_ACCESSION)).thenReturn(experiment);
+        when(experimentTraderMock.getExperiment(EXPERIMENT_ACCESSION,"")).thenReturn(experiment);
 
         var result = subject.getDownloads(EXPERIMENT_ACCESSION, "");
         assertThat(result)

--- a/app/src/test/java/uk/ac/ebi/atlas/search/geneids/GeneIdSearchDaoIT.java
+++ b/app/src/test/java/uk/ac/ebi/atlas/search/geneids/GeneIdSearchDaoIT.java
@@ -23,6 +23,7 @@ import uk.ac.ebi.atlas.solr.cloud.collections.BioentitiesCollectionProxy;
 import uk.ac.ebi.atlas.solr.cloud.search.SolrQueryBuilder;
 import uk.ac.ebi.atlas.solr.cloud.search.streamingexpressions.source.SearchStreamBuilder;
 import uk.ac.ebi.atlas.testutils.JdbcUtils;
+import uk.ac.ebi.atlas.trader.ExperimentTraderDao;
 
 import javax.inject.Inject;
 import javax.sql.DataSource;
@@ -51,6 +52,9 @@ class GeneIdSearchDaoIT {
 
     private BioentitiesCollectionProxy bioentitiesCollectionProxy;
 
+    @Inject
+    private ExperimentTraderDao experimentTraderDao;
+
     private GeneIdSearchDao subject;
 
     @BeforeAll
@@ -71,7 +75,7 @@ class GeneIdSearchDaoIT {
 
     @BeforeEach
     void setUp() {
-        subject = new GeneIdSearchDao(collectionProxyFactory);
+        subject = new GeneIdSearchDao(collectionProxyFactory, experimentTraderDao);
         bioentitiesCollectionProxy = collectionProxyFactory.create(BioentitiesCollectionProxy.class);
     }
 

--- a/docker/atlas-properties/jdbc.properties
+++ b/docker/atlas-properties/jdbc.properties
@@ -1,4 +1,4 @@
-jdbc.url = jdbc:postgresql://scxa-postgres:5432/gxpscxadev
-jdbc.username = atlasprd3
-jdbc.password = atlasprd3
+jdbc.url = jdbc:postgresql://scxa-postgres:5432/gxpatlasloc
+jdbc.username = atlas3dev
+jdbc.password = atlas3dev
 jdbc.pool = gxasc

--- a/docker/atlas-properties/jdbc.properties
+++ b/docker/atlas-properties/jdbc.properties
@@ -1,4 +1,4 @@
-jdbc.url = jdbc:postgresql://scxa-postgres:5432/gxpatlasloc
-jdbc.username = atlas3dev
-jdbc.password = atlas3dev
+jdbc.url = jdbc:postgresql://scxa-postgres:5432/gxpscxadev
+jdbc.username = atlasprd3
+jdbc.password = atlasprd3
 jdbc.pool = gxasc

--- a/docker/docker-compose-gradle.yml
+++ b/docker/docker-compose-gradle.yml
@@ -11,7 +11,6 @@ services:
     working_dir: /root/project
     volumes:
       - ..:/root/project
-      - root-gradle-cache:/root/.gradle
       - ./packages:/root/.m2
       - $ATLAS_DATA_PATH:/root/scxa/integration-test-data
     depends_on:
@@ -41,10 +40,6 @@ services:
         ./gradlew -PtestResultsPath=it -PexcludeTests=**/*WIT.class :app:test --tests *IT &&
         ./gradlew -PtestResultsPath=e2e :app:test --tests *WIT &&
         ./gradlew :app:jacocoTestReport
-
-volumes:
-  root-gradle-cache:
-    name: root-gradle-cache
 
 networks:
   scxa:

--- a/docker/docker-compose-gradle.yml
+++ b/docker/docker-compose-gradle.yml
@@ -11,6 +11,7 @@ services:
     working_dir: /root/project
     volumes:
       - ..:/root/project
+      - root-gradle-cache:/root/.gradle
       - ./packages:/root/.m2
       - $ATLAS_DATA_PATH:/root/scxa/integration-test-data
     depends_on:
@@ -40,6 +41,10 @@ services:
         ./gradlew -PtestResultsPath=it -PexcludeTests=**/*WIT.class :app:test --tests *IT &&
         ./gradlew -PtestResultsPath=e2e :app:test --tests *WIT &&
         ./gradlew :app:jacocoTestReport
+
+volumes:
+  root-gradle-cache:
+    name: root-gradle-cache
 
 networks:
   scxa:


### PR DESCRIPTION
This feature allows users to see private experiments if they know the access key in the single cell.
Companion PR: https://github.com/ebi-gene-expression-group/atlas-web-core/pull/70