### PR TITLE
Feature #179903156 – Merge same marker gene to one row

### DIFF
--- a/app/src/test/java/uk/ac/ebi/atlas/experimentpage/markergenes/HighchartsHeatmapAdapterTest.java
+++ b/app/src/test/java/uk/ac/ebi/atlas/experimentpage/markergenes/HighchartsHeatmapAdapterTest.java
@@ -3,6 +3,7 @@ package uk.ac.ebi.atlas.experimentpage.markergenes;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import org.apache.calcite.adapter.java.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -12,6 +13,12 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import uk.ac.ebi.atlas.bioentity.properties.BioEntityPropertyDao;
 
+import java.util.Arrays;
+import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
+
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static org.apache.commons.lang3.RandomStringUtils.randomAlphabetic;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 import static uk.ac.ebi.atlas.testutils.RandomDataTestUtils.generateRandomEnsemblGeneId;
@@ -20,6 +27,7 @@ import static uk.ac.ebi.atlas.testutils.RandomDataTestUtils.generateRandomGeneSy
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
 class HighchartsHeatmapAdapterTest {
+    private final static ThreadLocalRandom RNG = ThreadLocalRandom.current();
 
     @Mock
     private BioEntityPropertyDao bioEntityPropertyDaoMock;
@@ -89,5 +97,54 @@ class HighchartsHeatmapAdapterTest {
         assertThat(result).element(0).extracting("geneName").containsOnly(geneSymbol1);
         assertThat(result).element(1).extracting("geneName").containsOnly(geneSymbol2);
         assertThat(result).element(2).extracting("geneName").containsOnly(gene3);
+    }
+
+    @Test
+    void mergesMultipleGeneIdsAcrossGroupsIntoOneRowWithLowestPValue() {
+        var geneId = generateRandomEnsemblGeneId();
+
+        // With integers, we can test the lexicographical and numerical ordering with the same set of test data
+        var cellGroupValueWhereMarker1 = Integer.toString(RNG.nextInt());
+        var cellGroupValueWhereMarker2 = Integer.toString(RNG.nextInt());
+        while (cellGroupValueWhereMarker1.equals(cellGroupValueWhereMarker2)) {
+            cellGroupValueWhereMarker2 = Integer.toString(RNG.nextInt());
+        }
+
+        var pValue1 = RNG.nextDouble();
+        // pvalue1 is the bound, and pValue2 will be the reference marker gene
+        var pValue2 = RNG.nextDouble(pValue1);
+
+        var markerGene1 = MarkerGene.create(
+                geneId,
+                "inferred cell type",
+                cellGroupValueWhereMarker1,
+                pValue1,
+                Integer.toString(RNG.nextInt()),
+                RNG.nextInt(1000000),
+                RNG.nextInt(1000000));
+
+        var markerGene2 = MarkerGene.create(
+                geneId,
+                "inferred cell type",
+                cellGroupValueWhereMarker2,
+                pValue2,
+                Integer.toString(RNG.nextInt()),
+                RNG.nextInt(1000000),
+                RNG.nextInt(1000000));
+
+        when(bioEntityPropertyDaoMock.getSymbolsForGeneIds(ImmutableSet.of(geneId)))
+                .thenReturn(ImmutableMap.of(geneId, geneId));
+
+        assertThat(subject.getMarkerGeneHeatmapDataSortedLexicographically(ImmutableSet.of(markerGene1, markerGene2)))
+                .extracting("y")
+                .containsOnly(0);
+
+        assertThat(subject.getMarkerGeneHeatmapDataSortedNumerically(ImmutableSet.of(markerGene1, markerGene2)))
+                .extracting("y")
+                .containsOnly(0);
+
+        assertThat(subject.getMarkerGeneHeatmapDataSortedNumerically(ImmutableSet.of(markerGene1, markerGene2)))
+                .extracting("cellGroupValueWhereMarker")
+                .containsOnly(cellGroupValueWhereMarker2);
     }
 }

--- a/docker/docker-compose-gradle.yml
+++ b/docker/docker-compose-gradle.yml
@@ -10,6 +10,8 @@ services:
       - "5005:5005"
     working_dir: /root/project
     volumes:
+      - root-gradle-wrapper:/root/.gradle/wrapper
+      - root-gradle-caches:/root/.gradle/caches
       - ..:/root/project
       - ./packages:/root/.m2
       - $ATLAS_DATA_PATH:/root/scxa/integration-test-data
@@ -40,6 +42,10 @@ services:
         ./gradlew -PtestResultsPath=it -PexcludeTests=**/*WIT.class :app:test --tests *IT &&
         ./gradlew -PtestResultsPath=e2e :app:test --tests *WIT &&
         ./gradlew :app:jacocoTestReport
+
+volumes:
+  root-gradle-wrapper:
+  root-gradle-caches:
 
 networks:
   scxa:


### PR DESCRIPTION
We suffered a regression after adding the cell group tables to our DB. Before we only picked the marker gene in the group/cluster in which it had the lowest p-value. The merge now is done on the back end code, at serialisation time, since it’s a visualisation decision.

I also added some volumes to cache Gradle artifacts to speed up builds.