### PR TITLE
Refactor to correctly select colourBy category

### DIFF
--- a/app/src/main/javascript/bundles/experiment-page/html/index.html
+++ b/app/src/main/javascript/bundles/experiment-page/html/index.html
@@ -125,7 +125,7 @@
             "tsne": [{ "perplexity": 40 }, { "perplexity": 25 }, { "perplexity": 45 },{ "perplexity": 1 },{ "perplexity": 30 },
             {"perplexity": 10 },{ "perplexity": 15 },{ "perplexity": 50 },{ "perplexity": 35 },{ "perplexity": 20 },{ "perplexity": 5 }],
             "umap": [{"n_neighbors": 5},{"n_neighbors": 100},{"n_neighbors": 50},{"n_neighbors": 10},{"n_neighbors": 30},{"n_neighbors": 15},{"n_neighbors": 3}]
-          }
+          },
           suggesterEndpoint: 'json/suggestions'
         }
       },

--- a/app/src/main/javascript/bundles/experiment-page/src/TSnePlotViewRoute.js
+++ b/app/src/main/javascript/bundles/experiment-page/src/TSnePlotViewRoute.js
@@ -43,6 +43,7 @@ class TSnePlotViewRoute extends React.Component {
      ]
 
     const cellTypeValue = _first(_intersection(_map(this.props.metadata,`label`), this.props.initialCellTypeValues))
+    const search = URI(this.props.location.search).search(true)
 
     this.state = {
       selectedPlotType: plotTypeDropdown[0].plotType.toLowerCase(),
@@ -53,7 +54,7 @@ class TSnePlotViewRoute extends React.Component {
       selectedColourBy: cellTypeValue ? cellTypeValue.toLowerCase() : this.props.ks[Math.round((this.props.ks.length -1) / 2)].toString(),
       highlightClusters: [],
       experimentAccession: this.props.experimentAccession,
-      selectedColourByCategory: cellTypeValue ? `metadata` : `clusters`
+      selectedColourByCategory: !isNaN(search.colourBy) ? `clusters` : cellTypeValue ? `metadata` : `clusters`
     }
   }
 


### PR DESCRIPTION
TSne plot was not being correctly coloured when going through a URL. Details are in this [story](https://www.pivotaltracker.com/story/show/180331840).

The reason was that by default if there are cell types in the metadata prop then `metadata` was chosen as a default category to colour plots without checking the params passed in the URL. The issue has been resolved by checking URL params first to see if colourBy param is an integer or not and then selecting proper colourBy category.