### PR TITLE
Update to latest atlas-web-core, fix artifactory

### DIFF
--- a/.github/workflows/web-app-pr.yaml
+++ b/.github/workflows/web-app-pr.yaml
@@ -1,0 +1,24 @@
+name: Build atlas-web-single-cell WAR
+on:
+  pull_request
+
+jobs:
+  compile_war:
+    name: compile_war
+    strategy:
+      fail-fast: false #  if one of the jobs in the matrix expansion fails, the rest of the jobs will be cancelled
+      matrix:
+        os: ["ubuntu-latest"]
+        jdk: [11]
+    runs-on: ${{ matrix.os }}
+    env:
+      JDK_VERSION: ${{ matrix.jdk }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+      - uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.jdk }}
+      - name: Compile cli
+        run: ./gradlew --no-daemon :app:war

--- a/app/src/main/java/uk/ac/ebi/atlas/configuration/AppConfig.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/configuration/AppConfig.java
@@ -37,6 +37,11 @@ public class AppConfig {
             public HashSet<String> getBioentityIdsFromExperiment(String experimentAccession) {
                 return new HashSet<>();
             }
+
+            @Override
+            public HashSet<String> getBioentityIdsFromExperiment(String experimentAccession, boolean throwError) {
+                return new HashSet<>();
+            }
         };
     }
 

--- a/app/src/test/java/uk/ac/ebi/atlas/configuration/TestConfig.java
+++ b/app/src/test/java/uk/ac/ebi/atlas/configuration/TestConfig.java
@@ -38,6 +38,11 @@ public class TestConfig {
             public HashSet<String> getBioentityIdsFromExperiment(String experimentAccession) {
                 return new HashSet<>();
             }
+
+            @Override
+            public HashSet<String> getBioentityIdsFromExperiment(String experimentAccession, boolean throwError) {
+                return new HashSet<>();
+            }
         };
     }
 

--- a/buildSrc/src/main/groovy/atlas-web-app.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/atlas-web-app.java-conventions.gradle
@@ -13,7 +13,7 @@ repositories {
   mavenCentral()
   mavenLocal()
   maven {
-    url "http://193.62.54.19:30007/artifactory/maven-local/"
+    url "http://45.88.81.176/artifactory/maven-local/"
     allowInsecureProtocol true
   }
   // For patched version of SolrJ (see dependencies below) and ae-efo-loader


### PR DESCRIPTION
This PR adapts this repo to the changes I introduced in Atlas web core. Artifactory URL was pointing to older IP. There are more compilation errors that need to be fixed with the newer atlas-web-core.