### PR TITLE
Bugfix #182315539 - Add organism in payload field

### DIFF
--- a/app/src/main/java/uk/ac/ebi/atlas/search/AnalyticsSuggesterServiceImpl.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/search/AnalyticsSuggesterServiceImpl.java
@@ -25,7 +25,7 @@ public class AnalyticsSuggesterServiceImpl implements AnalyticsSuggesterService 
     public static final int DEFAULT_MAX_NUMBER_OF_SUGGESTIONS = 10;
     private final AnalyticsSuggesterDao analyticsSuggesterDao;
     private final SpeciesFactory speciesFactory;
-    
+
     private static final Function<Suggestion, Map<String, String>> SUGGESTION_TO_MAP =
             suggestion -> ImmutableMap.of("term", suggestion.getTerm(), "category", "metadata");
 
@@ -42,8 +42,9 @@ public class AnalyticsSuggesterServiceImpl implements AnalyticsSuggesterService 
                         .map(Species::getName)
                         .collect(toImmutableSet());
         var response = analyticsSuggesterDao.fetchMetadataSuggestions(query, DEFAULT_MAX_NUMBER_OF_SUGGESTIONS);
+
         return response
-                .filter(suggestion -> speciesNames.contains(suggestion.getPayload()))
+                .filter(suggestion -> speciesNames.isEmpty() || speciesNames.contains(suggestion.getPayload()))
                 .map(SUGGESTION_TO_MAP);
     }
 }

--- a/app/src/main/java/uk/ac/ebi/atlas/search/AutocompleteController.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/search/AutocompleteController.java
@@ -79,10 +79,10 @@ public class AutocompleteController extends JsonExceptionHandlingController {
     @GetMapping(value = "/json/suggestions/meta_data",
             produces = "application/json;charset=UTF-8")
     @ResponseStatus(HttpStatus.OK)
-    public String fetchMetaDataSuggestions( @RequestParam(value = "query") String query,
-                                            @RequestParam(value = "species", required = false, defaultValue = "") String species){
+    public String fetchMetadataSuggestions(@RequestParam(value = "query") String query,
+                                           @RequestParam(value = "species", required = false, defaultValue = "") String species){
       return GSON.toJson(SolrSuggestionReactSelectAdapter.serialize(
-                analyticsSuggesterService.fetchMetaDataSuggestions(
+                analyticsSuggesterService.fetchMetadataSuggestions(
                 query,species.split(","))));
     }
 

--- a/app/src/main/java/uk/ac/ebi/atlas/search/SingleCellAnalyticsSuggesterDao.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/search/SingleCellAnalyticsSuggesterDao.java
@@ -36,37 +36,40 @@ public class SingleCellAnalyticsSuggesterDao implements AnalyticsSuggesterDao {
     }
 
     @Override
-    public Stream<Suggestion> fetchMetaDataSuggestions(String query, int limit, Species... species) {
-        return fetchOntologyAnnoationSuggestions(query, limit, species);
-    }
-
-    private Stream<Suggestion> fetchOntologyAnnoationSuggestions(String query, int limit, Species... species) {
-
-        // We want the user to go beyond one keystroke to get some suggestions
-        if (query.length() < 2) {
+    public Stream<Suggestion> fetchMetadataSuggestions(String query, int limit) {
+        // We want the user to go beyond two keystrokes to get some suggestions
+        if (query.length() < 3) {
             return Stream.empty();
         }
 
-        var compareByWeightLengthAlphabetical = Comparator.comparingLong(Suggestion::getWeight).reversed()
-                .thenComparingInt(suggestion -> suggestion.getTerm().length())
-                .thenComparing(Suggestion::getTerm);
+        var compareByWeightLengthAlphabetical =
+                Comparator.comparingLong(Suggestion::getWeight)
+                        .reversed()
+                        .thenComparingInt(suggestion -> suggestion.getTerm().length())
+                        .thenComparing(Suggestion::getTerm);
 
         var solrQuery = new SolrQuery();
         solrQuery.setRequestHandler("/suggest")
                 .setParam("suggest.dictionary", DICTIONARIES)
                 .setParam("suggest.q", query)
                 // We raise suggest.count to a high enough value to get exact matches (the default is 100)
-                .setParam("suggest.count", "750").setParam("suggest.cfq",
-                Arrays.stream(species).map(Species::getEnsemblName).collect(joining(" ")));
-        return fetchAnalyticsSuggestions(solrQuery,compareByWeightLengthAlphabetical,limit);
+                .setParam("suggest.count", "1000");
+        return fetchAnalyticsSuggestions(solrQuery, compareByWeightLengthAlphabetical, limit);
     }
 
-    private Stream<Suggestion> fetchAnalyticsSuggestions(SolrQuery solrQuery,Comparator<Suggestion> compareByWeightLengthAlphabetical,int limit){
+    private Stream<Suggestion> fetchAnalyticsSuggestions(SolrQuery solrQuery,
+                                                         Comparator<Suggestion> comparator,
+                                                         int limit){
         try {
             return singleCellAnalyticsCollectionProxy.solrClient.query("scxa-analytics", solrQuery)
                     .getSuggesterResponse()
-                    .getSuggestions().values().stream().flatMap(List::stream)
-                    .distinct().sorted(compareByWeightLengthAlphabetical).limit(limit);
+                    .getSuggestions()
+                    .values()
+                    .stream()
+                    .flatMap(List::stream)
+                    .distinct()
+                    .sorted(comparator)
+                    .limit(limit);
         } catch (SolrServerException | IOException e) {
             LOGGER.error(e.getMessage(), e);
             throw new SolrException(SolrException.ErrorCode.UNKNOWN, e);

--- a/app/src/main/java/uk/ac/ebi/atlas/search/SingleCellAnalyticsSuggesterDao.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/search/SingleCellAnalyticsSuggesterDao.java
@@ -10,15 +10,11 @@ import org.springframework.stereotype.Repository;
 import uk.ac.ebi.atlas.search.suggester.AnalyticsSuggesterDao;
 import uk.ac.ebi.atlas.solr.cloud.SolrCloudCollectionProxyFactory;
 import uk.ac.ebi.atlas.solr.cloud.collections.SingleCellAnalyticsCollectionProxy;
-import uk.ac.ebi.atlas.species.Species;
 
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Stream;
-
-import static java.util.stream.Collectors.joining;
 
 @Repository
 public class SingleCellAnalyticsSuggesterDao implements AnalyticsSuggesterDao {
@@ -26,9 +22,9 @@ public class SingleCellAnalyticsSuggesterDao implements AnalyticsSuggesterDao {
 
     private SingleCellAnalyticsCollectionProxy singleCellAnalyticsCollectionProxy;
 
-    private static final String[] DICTIONARIES = {"ontologyAnnotationSuggester", "ontologyAnnotationAncestorSuggester",
-                    "ontologyAnnotationParentSuggester", "ontologyAnnotationSynonymSuggester",
-                    "ontologyAnnotationChildSuggester"};
+    private static final String[] DICTIONARIES = {
+            "ontologyAnnotationSuggester", "ontologyAnnotationAncestorSuggester",
+            "ontologyAnnotationParentSuggester", "ontologyAnnotationSynonymSuggester"};
 
     public SingleCellAnalyticsSuggesterDao(SolrCloudCollectionProxyFactory solrCloudCollectionProxyFactory) {
         this.singleCellAnalyticsCollectionProxy =

--- a/app/src/main/webapp/WEB-INF/jsp/tiles/views/cell-type-wheel-experiment-heatmap.jsp
+++ b/app/src/main/webapp/WEB-INF/jsp/tiles/views/cell-type-wheel-experiment-heatmap.jsp
@@ -12,8 +12,7 @@
     document.addEventListener('DOMContentLoaded', function (event) {
         cellTypeWheelHeatmap.render(
             {
-                //change it to 'http://localhost:8080/gxa/sc/' for local testing until its deployed on wwwdev
-                host: 'https://wwwdev.ebi.ac.uk/gxa/sc/',
+                host: '${pageContext.request.contextPath}/',
                 resource: 'json/cell-type-wheel/${cellTypeWheelSearchTerm}',
                 cellTypeWheelSearchTerm: '${cellTypeWheelSearchTerm}'
             },

--- a/app/src/test/java/uk/ac/ebi/atlas/search/AnalyticsSuggesterServiceIT.java
+++ b/app/src/test/java/uk/ac/ebi/atlas/search/AnalyticsSuggesterServiceIT.java
@@ -36,18 +36,18 @@ class AnalyticsSuggesterServiceIT {
     }
 
     @Test
-    void canFetchMetaDataSuggestionsForTheOrganismPartOrOrganism() {
-        assertThat(subject.fetchMetaDataSuggestions("skin", ArrayUtils.toArray()))
+    void canFetchMetadataSuggestionsForTheOrganismPartOrOrganism() {
+        assertThat(subject.fetchMetadataSuggestions("skin", ArrayUtils.toArray()))
                 .isNotEmpty();
-        assertThat(subject.fetchMetaDataSuggestions("Homo", ArrayUtils.toArray()))
+        assertThat(subject.fetchMetadataSuggestions("Homo", ArrayUtils.toArray()))
                 .isNotEmpty();
     }
 
     @Test
-    void canFetchMetaDataSuggestionsForTheCellTypeOrDisease(){
-        assertThat(subject.fetchMetaDataSuggestions("B cell", ArrayUtils.toArray()))
+    void canFetchMetadataSuggestionsForTheCellTypeOrDisease(){
+        assertThat(subject.fetchMetadataSuggestions("B cell", ArrayUtils.toArray()))
                 .isNotEmpty();
-        assertThat(subject.fetchMetaDataSuggestions("cancer", ArrayUtils.toArray()))
+        assertThat(subject.fetchMetadataSuggestions("cancer", ArrayUtils.toArray()))
                 .isNotEmpty();
     }
 }

--- a/app/src/test/java/uk/ac/ebi/atlas/search/AnalyticsSuggesterServiceTest.java
+++ b/app/src/test/java/uk/ac/ebi/atlas/search/AnalyticsSuggesterServiceTest.java
@@ -10,18 +10,18 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import uk.ac.ebi.atlas.search.suggester.AnalyticsSuggesterDao;
 import uk.ac.ebi.atlas.search.suggester.AnalyticsSuggesterService;
+import uk.ac.ebi.atlas.species.Species;
 import uk.ac.ebi.atlas.species.SpeciesFactory;
 
 import java.util.stream.Stream;
 
-import static org.apache.commons.lang3.RandomStringUtils.randomAlphabetic;
 import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static uk.ac.ebi.atlas.testutils.RandomDataTestUtils.generateRandomSpecies;
 
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
@@ -32,28 +32,42 @@ class AnalyticsSuggesterServiceTest {
     @Mock
     private SpeciesFactory speciesFactoryMock;
 
+    private Species species;
+
     private AnalyticsSuggesterService subject;
 
     @BeforeEach
     void setUp() {
+        species = generateRandomSpecies();
+
+        when(speciesFactoryMock.create(species.getName()))
+                .thenReturn(species);
+
         when(suggesterDaoMock.fetchMetadataSuggestions(anyString(), anyInt()))
                 .thenReturn(Stream.of(
-                        new Suggestion(randomAlphanumeric(10), 10, randomAlphabetic(10)),
-                        new Suggestion(randomAlphanumeric(10), 20, randomAlphabetic(10)),
-                        new Suggestion(randomAlphanumeric(10), 10, randomAlphabetic(10))));
+                        new Suggestion(randomAlphanumeric(10), 10, species.getName()),
+                        new Suggestion(randomAlphanumeric(10), 20, generateRandomSpecies().getName()),
+                        new Suggestion(randomAlphanumeric(10), 10, generateRandomSpecies().getName())));
 
         subject = new AnalyticsSuggesterServiceImpl(suggesterDaoMock, speciesFactoryMock);
     }
 
     @Test
-    void fetchSuggestionsForAnyOrganismOrOrganismPartOrCellTypeOrDisease() {
-        assertThat(subject.fetchMetadataSuggestions(randomAlphanumeric(3), "")).isNotEmpty();
+    void fetchSuggestionsReturnsResultsWhenNoSpeciesIsSpecified() {
+        assertThat(subject.fetchMetadataSuggestions(randomAlphanumeric(3))).hasSize(3);
         verify(suggesterDaoMock).fetchMetadataSuggestions(anyString(), anyInt());
     }
 
     @Test
-    void mapSuggestionsAsConfigured() {
-        assertThat(subject.fetchMetadataSuggestions(randomAlphanumeric(3), ""))
-                .allMatch(mappedSuggestion -> mappedSuggestion.containsKey("term") && mappedSuggestion.containsKey("category"));
+    void allSuggestionsContainTermAndCategory() {
+        assertThat(subject.fetchMetadataSuggestions(randomAlphanumeric(3)))
+                .allMatch(mappedSuggestion ->
+                        mappedSuggestion.containsKey("term") && mappedSuggestion.containsKey("category"))
+                .hasSize(3);
+    }
+
+    @Test
+    void filteringSuggestionsBySpecies() {
+        assertThat(subject.fetchMetadataSuggestions(randomAlphanumeric(3), species.getName())).hasSize(1);
     }
 }

--- a/app/src/test/java/uk/ac/ebi/atlas/search/AnalyticsSuggesterServiceTest.java
+++ b/app/src/test/java/uk/ac/ebi/atlas/search/AnalyticsSuggesterServiceTest.java
@@ -36,7 +36,7 @@ class AnalyticsSuggesterServiceTest {
 
     @BeforeEach
     void setUp() {
-        when(suggesterDaoMock.fetchMetaDataSuggestions(anyString(), anyInt(), any()))
+        when(suggesterDaoMock.fetchMetadataSuggestions(anyString(), anyInt()))
                 .thenReturn(Stream.of(
                         new Suggestion(randomAlphanumeric(10), 10, randomAlphabetic(10)),
                         new Suggestion(randomAlphanumeric(10), 20, randomAlphabetic(10)),
@@ -47,13 +47,13 @@ class AnalyticsSuggesterServiceTest {
 
     @Test
     void fetchSuggestionsForAnyOrganismOrOrganismPartOrCellTypeOrDisease() {
-        assertThat(subject.fetchMetaDataSuggestions(randomAlphanumeric(3), "")).isNotEmpty();
-        verify(suggesterDaoMock).fetchMetaDataSuggestions(anyString(), anyInt(), any());
+        assertThat(subject.fetchMetadataSuggestions(randomAlphanumeric(3), "")).isNotEmpty();
+        verify(suggesterDaoMock).fetchMetadataSuggestions(anyString(), anyInt());
     }
 
     @Test
     void mapSuggestionsAsConfigured() {
-        assertThat(subject.fetchMetaDataSuggestions(randomAlphanumeric(3), ""))
+        assertThat(subject.fetchMetadataSuggestions(randomAlphanumeric(3), ""))
                 .allMatch(mappedSuggestion -> mappedSuggestion.containsKey("term") && mappedSuggestion.containsKey("category"));
     }
 }

--- a/app/src/test/java/uk/ac/ebi/atlas/search/AutocompleteControllerWIT.java
+++ b/app/src/test/java/uk/ac/ebi/atlas/search/AutocompleteControllerWIT.java
@@ -136,7 +136,7 @@ class AutocompleteControllerWIT {
     }
 
     @Test
-    void canSeeSuggestionsForTheMetaData() throws Exception {
+    void canSeeSuggestionsForMetadata() throws Exception {
         this.mockMvc.perform(get("/json/suggestions/gene_search")
                 .param("species", "")
                 .param("query", "cancer"))

--- a/app/src/test/java/uk/ac/ebi/atlas/search/SingleCellAnalyticsSuggesterDaoIT.java
+++ b/app/src/test/java/uk/ac/ebi/atlas/search/SingleCellAnalyticsSuggesterDaoIT.java
@@ -24,26 +24,25 @@ class SingleCellAnalyticsSuggesterDaoIT {
 
     @Test
     void canFetchSuggestionsForOrganismAndOrganismPrt() {
-        assertThat(subject.fetchMetaDataSuggestions("Homo", 10, ArrayUtils.toArray())).isNotEmpty();
-        assertThat(subject.fetchMetaDataSuggestions("skin", 10, ArrayUtils.toArray())).isNotEmpty();
+        assertThat(subject.fetchMetadataSuggestions("Homo", 10)).isNotEmpty();
+        assertThat(subject.fetchMetadataSuggestions("skin", 10)).isNotEmpty();
     }
 
     @Test
     void canFetchSuggestionsForCellTypeAndDisease() {
-        assertThat(subject.fetchMetaDataSuggestions("B cell", 10, ArrayUtils.toArray())).isNotEmpty();
-        assertThat(subject.fetchMetaDataSuggestions("cancer", 10, ArrayUtils.toArray())).isNotEmpty();
+        assertThat(subject.fetchMetadataSuggestions("B cell", 10)).isNotEmpty();
+        assertThat(subject.fetchMetadataSuggestions("cancer", 10)).isNotEmpty();
     }
 
     @Test
     void doesNotContainDuplicateSuggestions() {
         String query = randomAlphabetic(3, 4);
-        var result = subject.fetchMetaDataSuggestions(query.toLowerCase(), 10, ArrayUtils.toArray())
-                .collect(toImmutableList());;
+        var result = subject.fetchMetadataSuggestions(query.toLowerCase(), 10).collect(toImmutableList());;
         assertThat(result).hasSameSizeAs(result.stream().distinct().collect(toImmutableList()));
     }
 
     @Test
     void atLeastTwoCharactersRequiredToFetchSuggestions() {
-        assertThat(subject.fetchMetaDataSuggestions("a", 10, ArrayUtils.toArray())).isEmpty();
+        assertThat(subject.fetchMetadataSuggestions("a", 10)).isEmpty();
     }
 }

--- a/compile-front-end-packages.sh
+++ b/compile-front-end-packages.sh
@@ -4,7 +4,7 @@
 for APP in npm ncu
 do
   if ! which $APP; then
-    echo "$APP is not installed." && exit 1
+    echo "$APP is not installed. Install Node and then run \`npm install -g npm-check-updates\`." && exit 1
   fi
 done
 

--- a/docker/docker-compose-gradle.yml
+++ b/docker/docker-compose-gradle.yml
@@ -5,7 +5,7 @@ services:
     image: openjdk:11
     container_name: scxa-gradle
     networks:
-      - scxa
+      - atlas-test-net
     ports:
       - "5005:5005"
     working_dir: /root/project
@@ -16,6 +16,7 @@ services:
       - ./packages:/root/.m2
       - gradle-ro-dep-cache:/gradle-ro-dep-cache
       - $ATLAS_DATA_PATH/scxa:/atlas-data/scxa
+      - $ATLAS_DATA_PATH/gxa:/atlas-data/gxa
       - $ATLAS_DATA_PATH/bioentity_properties:/atlas-data/bioentity_properties
 
     depends_on:
@@ -53,5 +54,5 @@ volumes:
   gradle-ro-dep-cache:
 
 networks:
-  scxa:
-    name: scxa
+  atlas-test-net:
+    name: atlas-test-net

--- a/docker/docker-compose-postgres-test.yml
+++ b/docker/docker-compose-postgres-test.yml
@@ -5,7 +5,7 @@ services:
     image: postgres:10-alpine
     container_name: $POSTGRES_HOST
     networks:
-      - scxa
+      - atlas-test-net
     restart: always
     command: -c max_wal_size=2GB
     environment:
@@ -20,7 +20,7 @@ services:
     image: flyway/flyway
     container_name: scxa-flyway-test
     networks:
-      - scxa
+      - atlas-test-net
     command: -url=jdbc:postgresql://$POSTGRES_HOST/$POSTGRES_DB -schemas=$POSTGRES_USER -user=$POSTGRES_USER -password=$POSTGRES_PASSWORD -connectRetries=60 migrate
     volumes:
       - ../schemas/flyway/scxa/:/flyway/sql
@@ -28,5 +28,5 @@ services:
       - scxa-postgres-test
 
 networks:
-  scxa:
-    name: scxa
+  atlas-test-net:
+    name: atlas-test-net

--- a/docker/docker-compose-postgres.yml
+++ b/docker/docker-compose-postgres.yml
@@ -5,7 +5,7 @@ services:
     image: postgres:10-alpine
     container_name: $POSTGRES_HOST
     networks:
-      - scxa
+      - atlas-test-net
     command: -c max_wal_size=2GB
     environment:
       POSTGRES_USER: $POSTGRES_USER
@@ -20,7 +20,7 @@ services:
     image: flyway/flyway
     container_name: scxa-flyway
     networks:
-      - scxa
+      - atlas-test-net
     command: -url=jdbc:postgresql://$POSTGRES_HOST/$POSTGRES_DB -schemas=$POSTGRES_USER -user=$POSTGRES_USER -password=$POSTGRES_PASSWORD -connectRetries=60 migrate
     volumes:
       - ../schemas/flyway/scxa/:/flyway/sql
@@ -32,5 +32,5 @@ volumes:
       name: scxa-pgdata
 
 networks:
-    scxa:
-      name: scxa
+  atlas-test-net:
+      name: atlas-test-net

--- a/docker/docker-compose-solrcloud.yml
+++ b/docker/docker-compose-solrcloud.yml
@@ -5,7 +5,7 @@ services:
     image: zookeeper:3.4.14
     container_name: scxa-zk-1
     networks:
-      - scxa
+      - atlas-test-net
     ports:
       - "2181:2181"
     volumes:
@@ -19,7 +19,7 @@ services:
     image: zookeeper:3.4.14
     container_name: scxa-zk-2
     networks:
-      - scxa
+      - atlas-test-net
     ports:
       - "2182:2181"
     volumes:
@@ -33,7 +33,7 @@ services:
     image: zookeeper:3.4.14
     container_name: scxa-zk-3
     networks:
-      - scxa
+      - atlas-test-net
     ports:
       - "2183:2181"
     volumes:
@@ -47,7 +47,7 @@ services:
     image: solr:7.1.0
     container_name: scxa-solrcloud-1
     networks:
-      - scxa
+      - atlas-test-net
     ports:
       - "8983:8983"
     volumes:
@@ -66,7 +66,7 @@ services:
     image: solr:7.1.0
     container_name: scxa-solrcloud-2
     networks:
-      - scxa
+      - atlas-test-net
     ports:
       - "8984:8983"
     volumes:
@@ -100,5 +100,5 @@ volumes:
     name: scxa-solrcloud-2-data
 
 networks:
-  scxa:
-    name: scxa
+  atlas-test-net:
+    name: atlas-test-net

--- a/docker/docker-compose-tomcat.yml
+++ b/docker/docker-compose-tomcat.yml
@@ -5,7 +5,7 @@ services:
     image: tomcat:9-jdk11
     container_name: scxa-tomcat
     networks:
-      - scxa
+      - atlas-test-net
     environment:
       JPDA_ADDRESS: "*:8000"
     ports:
@@ -14,7 +14,7 @@ services:
     volumes:
       - ../webapps:/usr/local/tomcat/webapps
       - ./atlas-properties:/atlas-properties
-      - $ATLAS_DATA_PATH/scxa/filesystem/scxa:/atlas-data/scxa
+      - $ATLAS_DATA_PATH/scxa:/atlas-data/scxa
       - $ATLAS_DATA_PATH/bioentity_properties:/atlas-data/bioentity_properties
       - scxa-tomcat-conf:/usr/local/tomcat/conf
     depends_on:
@@ -28,5 +28,5 @@ volumes:
     name: scxa-tomcat-conf
 
 networks:
-  scxa:
-    name: scxa
+  atlas-test-net:
+    name: atlas-test-net


### PR DESCRIPTION
To filter suggestions by species rather than using the `suggest.cfq` field we want to do it in the back end (see https://github.com/ebi-gene-expression-group/index-scxa/pull/37 for a more in-depth explanation).

The species argument has been removed from the DAO and a few improvements have been made here and there.

Accompanied by https://github.com/ebi-gene-expression-group/atlas-web-core/pull/108.