### PR TITLE
Feature #181415976 – Redirect metadata terms to cell type wheel page

### DIFF
--- a/app/src/main/java/uk/ac/ebi/atlas/search/SearchController.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/search/SearchController.java
@@ -29,20 +29,20 @@ public class SearchController extends HtmlExceptionHandlingController {
 
     @RequestMapping(value = SEARCH_ENDPOINT, method = RequestMethod.POST)
     public String parseJsonAsRequestParamsAndRedirect(
-            @RequestParam(value = "geneQuery") String geneQuery,
+            @RequestParam(value = "geneQuery") String query,
             @RequestParam(value = "species", defaultValue = "") String species) {
-        var geneQueryObject = GSON.fromJson(geneQuery, JsonObject.class);
+        var queryObject = GSON.fromJson(query, JsonObject.class);
 
         var searchUrlBuilder = UriComponentsBuilder
                 .newInstance()
                 .path(SEARCH_ENDPOINT);
 
-        if (geneQueryObject.get("category").getAsString().equals("metadata")) {
+        if (queryObject.get("category").getAsString().equals("metadata")) {
             searchUrlBuilder
-                    .pathSegment("metadata", geneQueryObject.get("term").getAsString());
+                    .pathSegment("metadata", queryObject.get("term").getAsString());
         } else {
             searchUrlBuilder
-                    .queryParam(geneQueryObject.get("category").getAsString(), geneQueryObject.get("term").getAsString())
+                    .queryParam(queryObject.get("category").getAsString(), queryObject.get("term").getAsString())
                     .queryParam("species", species);
         }
 

--- a/app/src/main/java/uk/ac/ebi/atlas/search/SearchController.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/search/SearchController.java
@@ -12,8 +12,6 @@ import org.springframework.web.util.UriComponentsBuilder;
 import uk.ac.ebi.atlas.controllers.HtmlExceptionHandlingController;
 import uk.ac.ebi.atlas.solr.bioentities.BioentityPropertyName;
 
-import java.util.List;
-
 import static java.util.stream.Collectors.toList;
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 import static uk.ac.ebi.atlas.solr.cloud.collections.BioentitiesCollectionProxy.BIOENTITY_PROPERTY_NAMES;
@@ -21,7 +19,7 @@ import static uk.ac.ebi.atlas.utils.GsonProvider.GSON;
 
 @Controller
 public class SearchController extends HtmlExceptionHandlingController {
-    private static final List<String> VALID_REQUEST_PARAMS =
+    private static final ImmutableList<String> VALID_REQUEST_PARAMS =
             ImmutableList.<String>builder()
                     .add("q")
                     .addAll(BIOENTITY_PROPERTY_NAMES.stream().map(BioentityPropertyName::name).collect(toList()))
@@ -33,24 +31,28 @@ public class SearchController extends HtmlExceptionHandlingController {
     public String parseJsonAsRequestParamsAndRedirect(
             @RequestParam(value = "geneQuery") String geneQuery,
             @RequestParam(value = "species", defaultValue = "") String species) {
-        JsonObject geneQueryObject = GSON.fromJson(geneQuery, JsonObject.class);
+        var geneQueryObject = GSON.fromJson(geneQuery, JsonObject.class);
 
-        String getSearchUrl = UriComponentsBuilder
+        var searchUrlBuilder = UriComponentsBuilder
                 .newInstance()
-                .path(SEARCH_ENDPOINT)
-                .queryParam(geneQueryObject.get("category").getAsString(), geneQueryObject.get("term").getAsString())
-                .queryParam("species", species)
-                .build()
-                .toUriString();
+                .path(SEARCH_ENDPOINT);
 
-        return "redirect:" + getSearchUrl;
+        if (geneQueryObject.get("category").getAsString().equals("metadata")) {
+            searchUrlBuilder
+                    .pathSegment("metadata", geneQueryObject.get("term").getAsString());
+        } else {
+            searchUrlBuilder
+                    .queryParam(geneQueryObject.get("category").getAsString(), geneQueryObject.get("term").getAsString())
+                    .queryParam("species", species);
+        }
 
+        return "redirect:" + searchUrlBuilder.build().toUriString();
     }
 
     @RequestMapping(value = SEARCH_ENDPOINT, method = RequestMethod.GET, produces = "text/html;charset=UTF-8")
     public String getSearch(@RequestParam MultiValueMap<String, String> requestParams,
                             Model model) {
-        String endpoint =
+        var endpoint =
                 UriComponentsBuilder
                         .newInstance()
                         .path("json/search")
@@ -64,8 +66,8 @@ public class SearchController extends HtmlExceptionHandlingController {
             model.addAttribute("species", requestParams.getFirst("species"));
         }
 
-        for (String requestParam : requestParams.keySet()) {
-            for (String idPropertyName : VALID_REQUEST_PARAMS) {
+        for (var requestParam : requestParams.keySet()) {
+            for (var idPropertyName : VALID_REQUEST_PARAMS) {
                 if (requestParam.equalsIgnoreCase(idPropertyName)) {
                     model.addAttribute("geneQueryTerm", requestParams.getFirst(requestParam));
                     model.addAttribute("geneQueryCategory", requestParam);
@@ -76,5 +78,4 @@ public class SearchController extends HtmlExceptionHandlingController {
 
         return "gene-search-results";
     }
-
 }

--- a/app/src/main/webapp/WEB-INF/jsp/tiles/views/download.jsp
+++ b/app/src/main/webapp/WEB-INF/jsp/tiles/views/download.jsp
@@ -2,53 +2,60 @@
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 
 <div class="row">
-    <div class="12 columns">
-        <h2>Download</h2>
+  <div class="12 columns">
+    <h2>Download</h2>
 
-        <h3>Via FTP</h3>
-        <p>
-            You can download data for every dataset individually in Expression Atlas through our
-            <a href="http://ftp.ebi.ac.uk/pub/databases/microarray/data/atlas/sc_experiments/" target="_blank">FTP site</a>.
-        </p>
+    <h3>Via FTP</h3>
+    <p>
+      You can download data for every dataset individually in Expression Atlas through our
+      <a href="http://ftp.ebi.ac.uk/pub/databases/microarray/data/atlas/sc_experiments/" target="_blank">FTP
+        site</a>.
+    </p>
 
-        <h3>From experiment pages</h3>
-        <p>
-            You can download single experiment files from the <i>Downloads</i> tab in any experiment page. Below is
-            a short summary about data that you can download.
-        </p>
+    <h3>From experiment pages</h3>
+    <p>
+      You can download single experiment files from the <i>Downloads</i> tab in any experiment page. Below is
+      a short summary about data that you can download.
+    </p>
 
-        <h4>Metadata files</h4>
-        <p>
-            <i class="icon icon-common icon-download"/>
-            Experiment metadata: SDRF and IDF files containing information about the experiment.
-        </p>
-        <p>
-            <i class="icon icon-fileformats icon-TSV"/>
-            Experiment design file: Information about assays within the experiment.
-        </p>
+    <h4>Metadata files</h4>
+    <ul style="list-style-type: none">
+      <li>
+        <span class="icon icon-common icon-download"/>
+        Experiment metadata: SDRF and IDF files containing information about the experiment.
+      </li>
+      <li>
+        <span class="icon icon-fileformats icon-TSV"/>
+        Experiment design file: Information about assays within the experiment.
 
-        <h4>Results Files</h4>
-        <p>
-            <i class="icon icon-fileformats icon-TSV"/>
-            Clustering file: Results of unsupervised louvain clustering at a range of resolution values.
-        </p>
-        <p>
-            <i class="icon icon-fileformats icon-TSV"/>
-            Marker gene files: Results of marker gene detection, as calculated by Scanpy using the Wilcoxon rank-sum method.
-        </p>
-        <p>
-            <i class="icon icon-common icon-download"/>
-            Normalised counts files: Untransformed expression values, normalised to counts per million.
-        </p>
-        <p>
-            <i class="icon icon-common icon-download"/>
-            Raw counts files: Raw counts values before filtering and normalisation.
-        </p>
-    </div>
+      </li>
+    </ul>
+
+    <h4>Results Files</h4>
+    <ul style="list-style-type: none">
+      <li>
+        <span class="icon icon-fileformats icon-TSV"/>
+        Clustering file: Results of unsupervised louvain clustering at a range of resolution values.
+      </li>
+      <li>
+        <span class="icon icon-fileformats icon-TSV"/>
+        Marker gene files: Results of marker gene detection, as calculated by Scanpy using the Wilcoxon rank-sum
+        method.
+      </li>
+      <li>
+        <span class="icon icon-common icon-download"/>
+        Normalised counts files: Untransformed expression values, normalised to counts per million.
+      </li>
+      <li>
+        <span class="icon icon-common icon-download"/>
+        Raw counts files: Raw counts values before filtering and normalisation.
+      </li>
+    </ul>
+  </div>
 </div>
 
 <script>
-    document.addEventListener("DOMContentLoaded", function(event) {
-        document.getElementById("local-nav-download").className += ' active';
-    });
+  document.addEventListener("DOMContentLoaded", function (event) {
+    document.getElementById("local-nav-download").className += ' active';
+  });
 </script>

--- a/app/src/test/java/uk/ac/ebi/atlas/search/SearchControllerWIT.java
+++ b/app/src/test/java/uk/ac/ebi/atlas/search/SearchControllerWIT.java
@@ -56,7 +56,7 @@ class SearchControllerWIT {
 
     @Test
     void invalidGeneQueryJsonReturnsError() throws Exception {
-        String randomString = randomAlphanumeric(10);
+        var randomString = randomAlphanumeric(10);
 
         this.mockMvc.perform(post("/search").param("geneQuery", randomString))
                 .andExpect(status().is4xxClientError());
@@ -64,8 +64,8 @@ class SearchControllerWIT {
 
     @Test
     void geneQueryJsonWithoutTermOrCategoryReturnsError() throws Exception {
-        String term = randomAlphanumeric(10);
-        String category = randomAlphanumeric(10);
+        var term = randomAlphanumeric(10);
+        var category = randomAlphanumeric(10);
 
         this.mockMvc.perform(post("/search").param("geneQuery", GSON.toJson(ImmutableMap.of("term", term))))
                 .andExpect(status().is4xxClientError());
@@ -75,8 +75,8 @@ class SearchControllerWIT {
 
     @Test
     void postRequestIsRedirectedToGetRequest() throws Exception {
-        String term = randomAlphanumeric(10);
-        String category = randomAlphanumeric(10);
+        var term = randomAlphanumeric(10);
+        var category = randomAlphanumeric(10);
 
         this.mockMvc.perform(
                 post("/search")
@@ -87,9 +87,9 @@ class SearchControllerWIT {
 
     @Test
     void geneQueryAndSpeciesParamsAreParsedAndAddedToGetRequest() throws Exception {
-        String term = randomAlphanumeric(10);
-        String category = randomAlphanumeric(10);
-        String species = randomAlphanumeric(4) + " " + randomAlphanumeric(6);
+        var term = randomAlphanumeric(10);
+        var category = randomAlphanumeric(10);
+        var species = randomAlphanumeric(4) + " " + randomAlphanumeric(6);
 
         this.mockMvc.perform(
                 post("/search")
@@ -101,11 +101,11 @@ class SearchControllerWIT {
 
     @Test
     void otherRequestParamsAreIgnored() throws Exception {
-        String term = randomAlphanumeric(10);
-        String category = randomAlphanumeric(10);
-        String species = randomAlphanumeric(4) + " " + randomAlphanumeric(6);
-        String otherRequestParam = randomAlphanumeric(10);
-        String otherRequestParamValue = randomAlphanumeric(10);
+        var term = randomAlphanumeric(10);
+        var category = randomAlphanumeric(10);
+        var species = randomAlphanumeric(4) + " " + randomAlphanumeric(6);
+        var otherRequestParam = randomAlphanumeric(10);
+        var otherRequestParamValue = randomAlphanumeric(10);
 
         this.mockMvc.perform(
                 post("/search")
@@ -118,8 +118,8 @@ class SearchControllerWIT {
 
     @Test
     void getSearchPassesAllRequestParamsToEndpoint() throws Exception {
-        String requestParam = randomAlphanumeric(10);
-        String requestParamValue = randomAlphanumeric(10);
+        var requestParam = randomAlphanumeric(10);
+        var requestParamValue = randomAlphanumeric(10);
 
         this.mockMvc.perform(get("/search").param(requestParam, requestParamValue))
             .andExpect(model().attribute("endpoint", is("json/search?" + requestParam + "=" + requestParamValue)));
@@ -150,5 +150,20 @@ class SearchControllerWIT {
                         .param("species", randomAlphanumeric(10)))
                 .andExpect(model().attribute("geneQueryTerm", is(randomString)))
                 .andExpect(model().attribute("geneQueryCategory", is("q")));
+    }
+
+    @Test
+    void metadataTermIsRedirectedToMetadataCellTypeWheelPage() throws Exception {
+        var term = randomAlphanumeric(10);
+        var category = "metadata";
+        var otherRequestParam = randomAlphanumeric(10);
+        var otherRequestParamValue = randomAlphanumeric(10);
+
+        this.mockMvc.perform(
+                        post("/search")
+                                .param("geneQuery", GSON.toJson(ImmutableMap.of("term", term, "category", category)))
+                                .param(otherRequestParam, otherRequestParamValue))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/search/metadata/" + term));
     }
 }


### PR DESCRIPTION
Not much to say, we parse the `queryObject` (which should come from the variable `query` rather than `geneQuery` to make it consistent, but since needs changes from the front end I decided to leave it be), and redirect to the cell type wheel page if the term is of category `metadata`.