### PR TITLE
Bugfix #261 – Gene search with any species sets request param `species=undefined`

### DIFF
--- a/app/src/main/javascript/bundles/gene-search/src/ExperimentCard.js
+++ b/app/src/main/javascript/bundles/gene-search/src/ExperimentCard.js
@@ -1,10 +1,8 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
-import formatNumber from 'format-number'
+import format from 'format-number'
 import EbiSpeciesIcon from '@ebi-gene-expression-group/react-ebi-species'
-
-const _formatNumber = formatNumber()
 
 const CardContainerDiv = styled.div`
   height: 100%;
@@ -93,7 +91,7 @@ class ExperimentCard extends React.Component {
             {factors.map(factor => <li key={`factor-${factor}`}> {factor} </li>)}
           </ul>
         </VariableDiv>
-        <CountDiv> {_formatNumber(numberOfAssays)} </CountDiv>
+        <CountDiv> {format(numberOfAssays)} </CountDiv>
       </CardContainerDiv>
     )
   }

--- a/app/src/main/javascript/bundles/gene-search/src/GeneSearch.js
+++ b/app/src/main/javascript/bundles/gene-search/src/GeneSearch.js
@@ -12,10 +12,16 @@ import ExperimentCard from './ExperimentCard'
 const GeneSearchFormWithFetchLoader = withFetchLoader(GeneSearchForm)
 const FacetedSearchResultsWithFetchLoader = withFetchLoader(FacetedSearchResults)
 
-const GeneSearch = ({atlasUrl, history}) => {
+function GeneSearch ({atlasUrl, history}) {
   const updateUrl = (event, query, species) => {
     event.preventDefault()
-    history.push(`/search?species=` + species + `&` + query.category + `=` + query.term)
+    history.push(
+      URI(`/search`)
+        .query({
+          [query.category]: query.term,
+          species: species
+        })
+        .toString())
   }
 
   const requestParams = URI(location.search).query(true)
@@ -55,20 +61,18 @@ const GeneSearch = ({atlasUrl, history}) => {
         firstMatchingRequestParam &&
         <FacetedSearchResultsWithFetchLoader
           host={atlasUrl}
-          resource={
-            `json/search?` +
-            URI.buildQuery({
-              [geneQuery.category]: geneQuery.term,
-              species: requestParams.species
-            })
-          }
+          resource={`json/search`}
+          query={{
+            [geneQuery.category]: geneQuery.term,
+            species: requestParams.species
+          }}
           fulfilledPayloadProvider={data => ({
             resultsMessage: data ?
               (data.results && data.results.length > 0) ?
                 `${geneQuery.term} ${data.matchingGeneId}  is expressed in:` :
                 `Your search for ${geneQuery.term} yielded no results: ${data.reason}` :
               `WTF!`
-            })
+          })
           }
           sortTitle={`markerGenes`}
           ResultsHeaderClass={ExperimentsHeader}


### PR DESCRIPTION
Create links in the browser History using URI rather than by manually wrangling strings.