### PR TITLE
Fix query for getting experiment accessions for marker gene IDs

### DIFF
--- a/app/src/main/java/uk/ac/ebi/atlas/search/GeneSearchDao.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/search/GeneSearchDao.java
@@ -76,7 +76,8 @@ public class GeneSearchDao {
     private static final String SELECT_EXPERIMENT_ACCESSIONS_FOR_MARKER_GENE_ID =
 			"SELECT experiment_accession FROM scxa_cell_group AS cell_group " +
 					"INNER JOIN experiment AS exp ON exp.accession = cell_group.experiment_accession " +
-					"INNER JOIN scxa_cell_group_marker_genes AS marker_genes ON marker_genes.gene_id = :gene_id " +
+					"INNER JOIN scxa_cell_group_marker_genes AS marker_genes ON " +
+                    "(cell_group.id = marker_genes.cell_group_id AND marker_genes.gene_id = :gene_id) " +
 					"WHERE private = FALSE GROUP BY experiment_accession";
 
     @Transactional(readOnly = true)

--- a/app/src/test/java/uk/ac/ebi/atlas/search/GeneSearchDaoIT.java
+++ b/app/src/test/java/uk/ac/ebi/atlas/search/GeneSearchDaoIT.java
@@ -97,10 +97,7 @@ class GeneSearchDaoIT {
         var result = subject.fetchExperimentAccessionsWhereGeneIsMarker(geneId);
 
         assertThat(result)
-                .contains("E-CURD-4");
-        //previous assertion is .containsOnly("E-CURD-4"), removed Only from above to fix test case
-        // Alfonso needs to review this assertion, because above method returns
-        // LIST of experiment accessions, not sure why we are using .containsOnly("E-CURD-4")
+                .containsOnly("E-CURD-4");
     }
 
     @ParameterizedTest


### PR DESCRIPTION
The query for getting experiment accessions for marker gene IDs was missing the join criteria between the `scxa_cell_group` and `scxa_cell_group_marker_genes` tables. Without that missing criteria, the query returns always all of the experiment accessions as the gene ID filter only filters the `scxa_cell_group_marker_genes` table, but does not connect that table to the other part of the SQL query.