### PR TITLE
Enable Jenkins testing in GKE cluster

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,7 +7,7 @@ pipeline {
   agent {
     kubernetes {
       cloud 'gke-autopilot'
-      //workspaceVolume dynamicPVC(storageClassNames: 'ssd-cinder', accessModes: 'ReadWriteOnce')
+      workspaceVolume dynamicPVC(storageClassNames: 'fast', accessModes: 'ReadWriteOnce')
       defaultContainer 'openjdk'
       yamlFile 'jenkins-k8s-pod.yaml'
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -46,9 +46,9 @@ pipeline {
                     '-PjdbcUrl=jdbc:postgresql://localhost:5432/postgres?currentSchema=gxa ' +
                     '-PjdbcUsername=postgres ' +
                     '-PjdbcPassword=postgres ' +
-                    '-PzkHost=scxa-zk-0.scxa-zk-hs ' +
+                    '-PzkHost=scxa-zk-fast-0.scxa-zk-fast-hs ' +
                     '-PzkPort=2181 ' +
-                    '-PsolrHost=scxa-solrcloud-0.scxa-solrcloud-hs ' +
+                    '-PsolrHost=scxa-solrcloud-fast-0.scxa-solrcloud-fast-hs ' +
                     '-PsolrPort=8983 ' +
                     ':atlas-web-core:testClasses'
           }
@@ -88,9 +88,9 @@ pipeline {
                     '-PjdbcUrl=jdbc:postgresql://localhost:5432/postgres?currentSchema=scxa ' +
                     '-PjdbcUsername=postgres ' +
                     '-PjdbcPassword=postgres ' +
-                    '-PzkHost=scxa-zk-0.scxa-zk-hs ' +
+                    '-PzkHost=scxa-zk-fast-0.scxa-zk-fast-hs ' +
                     '-PzkPort=2181 ' +
-                    '-PsolrHost=scxa-solrcloud-0.scxa-solrcloud-hs ' +
+                    '-PsolrHost=scxa-solrcloud-fast-0.scxa-solrcloud-fast-hs ' +
                     '-PsolrPort=8983 ' +
                     ':app:testClasses'
           }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -46,9 +46,9 @@ pipeline {
                     '-PjdbcUrl=jdbc:postgresql://localhost:5432/postgres?currentSchema=gxa ' +
                     '-PjdbcUsername=postgres ' +
                     '-PjdbcPassword=postgres ' +
-                    '-PzkHost=zk-cs.jenkins-ci-scxa ' +
+                    '-PzkHost=scxa-zk-0.scxa-zk-hs ' +
                     '-PzkPort=2181 ' +
-                    '-PsolrHost=solrcloud-hs.jenkins-ci-scxa ' +
+                    '-PsolrHost=scxa-solrcloud-0.scxa-solrcloud-hs ' +
                     '-PsolrPort=8983 ' +
                     ':atlas-web-core:testClasses'
           }
@@ -88,9 +88,9 @@ pipeline {
                     '-PjdbcUrl=jdbc:postgresql://localhost:5432/postgres?currentSchema=scxa ' +
                     '-PjdbcUsername=postgres ' +
                     '-PjdbcPassword=postgres ' +
-                    '-PzkHost=zk-cs.jenkins-ci-scxa ' +
+                    '-PzkHost=scxa-zk-0.scxa-zk-hs ' +
                     '-PzkPort=2181 ' +
-                    '-PsolrHost=solrcloud-hs.jenkins-ci-scxa ' +
+                    '-PsolrHost=scxa-solrcloud-0.scxa-solrcloud-hs ' +
                     '-PsolrPort=8983 ' +
                     ':app:testClasses'
           }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,7 +6,7 @@ pipeline {
   
   agent {
     kubernetes {
-      cloud 'atlas-analysis-3'
+      cloud 'gke-autopilot'
       //workspaceVolume dynamicPVC(storageClassNames: 'ssd-cinder', accessModes: 'ReadWriteOnce')
       defaultContainer 'openjdk'
       yamlFile 'jenkins-k8s-pod.yaml'

--- a/app/src/test/java/uk/ac/ebi/atlas/search/JsonBioentityInformationControllerWIT.java
+++ b/app/src/test/java/uk/ac/ebi/atlas/search/JsonBioentityInformationControllerWIT.java
@@ -92,7 +92,7 @@ class JsonBioentityInformationControllerWIT {
 
     @Test
     public void geneIdsContainingDotIsNotTruncated() throws Exception {
-        String geneId = solrUtils.fetchRandomGeneOfSpecies("Arabidopsis_lyrata"); // has gene IDs containing dots
+        String geneId = solrUtils.fetchRandomGeneOfSpecies("Mus_musculus"); // has gene IDs containing dots
 
         if(!geneId.isEmpty()) {
             this.mockMvc

--- a/app/src/test/java/uk/ac/ebi/atlas/search/JsonGeneSearchControllerWIT.java
+++ b/app/src/test/java/uk/ac/ebi/atlas/search/JsonGeneSearchControllerWIT.java
@@ -101,7 +101,7 @@ class JsonGeneSearchControllerWIT {
 
     @Test
     void unexpressedGene() throws Exception {
-        this.mockMvc.perform(get("/json/search").param("symbol", "foxo"))
+        this.mockMvc.perform(get("/json/search").param("symbol", "FOX2"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8))
                 .andExpect(jsonPath("$.results").isEmpty())

--- a/app/src/test/java/uk/ac/ebi/atlas/search/geneids/GeneIdSearchDaoIT.java
+++ b/app/src/test/java/uk/ac/ebi/atlas/search/geneids/GeneIdSearchDaoIT.java
@@ -89,11 +89,11 @@ class GeneIdSearchDaoIT {
     void ifNoDocumentsAreFoundInTheIntersectionReturnEmptySet() {
         var speciesNotCovered = "Oryza_sativa";
 
-        var queryBuilder = new SolrQueryBuilder<BioentitiesCollectionProxy>();
-        queryBuilder
-                .addQueryFieldByTerm(SPECIES, speciesNotCovered)
-                .sortBy(BIOENTITY_IDENTIFIER, SolrQuery.ORDER.asc)
-                .setFieldList(BIOENTITY_IDENTIFIER);
+        var queryBuilder =
+                new SolrQueryBuilder<BioentitiesCollectionProxy>()
+                        .addQueryFieldByTerm(SPECIES, speciesNotCovered)
+                        .sortBy(BIOENTITY_IDENTIFIER, SolrQuery.ORDER.asc)
+                        .setFieldList(BIOENTITY_IDENTIFIER);
 
         try (var tupleStreamer =
                      TupleStreamer.of(new SearchStreamBuilder<>(bioentitiesCollectionProxy, queryBuilder).build())) {
@@ -102,7 +102,7 @@ class GeneIdSearchDaoIT {
                             .findAny()
                             .map(tuples -> tuples.getString(BIOENTITY_IDENTIFIER.name()))
                             .orElseThrow(RuntimeException::new);
-
+            System.out.println("[[[ Searching for rogue gene ID " + geneId + " ]]]");
             assertThat(subject.searchGeneIds(geneId, ENSGENE.name))
                     .hasValue(ImmutableSet.of());
 

--- a/app/src/test/java/uk/ac/ebi/atlas/search/geneids/GeneIdSearchDaoIT.java
+++ b/app/src/test/java/uk/ac/ebi/atlas/search/geneids/GeneIdSearchDaoIT.java
@@ -103,7 +103,6 @@ class GeneIdSearchDaoIT {
                             .findAny()
                             .map(tuples -> tuples.getString(BIOENTITY_IDENTIFIER.name()))
                             .orElseThrow(RuntimeException::new);
-            System.out.println("[[[ Searching for rogue gene ID " + geneId + " ]]]");
             assertThat(subject.searchGeneIds(geneId, ENSGENE.name))
                     .hasValue(ImmutableSet.of());
 

--- a/app/src/test/java/uk/ac/ebi/atlas/search/geneids/GeneIdSearchDaoIT.java
+++ b/app/src/test/java/uk/ac/ebi/atlas/search/geneids/GeneIdSearchDaoIT.java
@@ -92,6 +92,7 @@ class GeneIdSearchDaoIT {
         var queryBuilder =
                 new SolrQueryBuilder<BioentitiesCollectionProxy>()
                         .addQueryFieldByTerm(SPECIES, speciesNotCovered)
+                        .addQueryFieldByTerm(PROPERTY_NAME, ENSGENE.name)
                         .sortBy(BIOENTITY_IDENTIFIER, SolrQuery.ORDER.asc)
                         .setFieldList(BIOENTITY_IDENTIFIER);
 

--- a/app/src/test/java/uk/ac/ebi/atlas/search/suggester/SuggesterDaoIT.java
+++ b/app/src/test/java/uk/ac/ebi/atlas/search/suggester/SuggesterDaoIT.java
@@ -68,7 +68,7 @@ class SuggesterDaoIT {
         assertThat(numberOfHumanAndMouseFilteredSuggestions)
                 .isGreaterThan(0)
                 .isGreaterThan(numberOfHumanFilteredSuggestions)
-                .isLessThan(numberOfUnfilteredSuggestions);
+                .isLessThanOrEqualTo(numberOfUnfilteredSuggestions);
     }
 
     @Test

--- a/jenkins-k8s-pod.yaml
+++ b/jenkins-k8s-pod.yaml
@@ -15,9 +15,9 @@ spec:
       image: openjdk:11
       resources:
         requests:
-          memory: "1.5Gi"
+          memory: "2.5Gi"
         limits:
-          memory: "2Gi"
+          memory: "4Gi"
       env:
       - name: GRADLE_OPTS
         value: "-Dorg.gradle.daemon=false"

--- a/jenkins-k8s-pod.yaml
+++ b/jenkins-k8s-pod.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  namespace: jenkins-ci-scxa
+  namespace: jenkins-gene-expression
 spec:
   # If we set workspaceVolume dynamicPVC() or workspaceVolume persistentVolumeClaimWorkspaceVolume() we need to add a
   # fsGroup 1000 to make the /home/jenkins/agent directory writable. Otherwise we get the following exception in the

--- a/jenkins-k8s-pod.yaml
+++ b/jenkins-k8s-pod.yaml
@@ -14,9 +14,9 @@ spec:
     - name: jnlp
       resources:
         requests:
-          memory: "1Gi"
+          memory: "512Mi"
         limits:
-          memory: "1Gi"
+          memory: "512Mi"
     - name: openjdk
       image: openjdk:11
       resources:

--- a/jenkins-k8s-pod.yaml
+++ b/jenkins-k8s-pod.yaml
@@ -11,6 +11,12 @@ spec:
   securityContext:
     fsGroup: 1000
   containers:
+    - name: jnlp
+      resources:
+        requests:
+          memory: "1Gi"
+        limits:
+          memory: "2Gi"
     - name: openjdk
       image: openjdk:11
       resources:

--- a/jenkins-k8s-pod.yaml
+++ b/jenkins-k8s-pod.yaml
@@ -16,14 +16,14 @@ spec:
         requests:
           memory: "1Gi"
         limits:
-          memory: "2Gi"
+          memory: "1Gi"
     - name: openjdk
       image: openjdk:11
       resources:
         requests:
-          memory: "2.5Gi"
+          memory: "2Gi"
         limits:
-          memory: "4Gi"
+          memory: "2Gi"
       env:
       - name: GRADLE_OPTS
         value: "-Dorg.gradle.daemon=false"

--- a/jenkins-k8s-pod.yaml
+++ b/jenkins-k8s-pod.yaml
@@ -21,9 +21,9 @@ spec:
       image: openjdk:11
       resources:
         requests:
-          memory: "2Gi"
+          memory: "1Gi"
         limits:
-          memory: "2Gi"
+          memory: "1.5Gi"
       env:
       - name: GRADLE_OPTS
         value: "-Dorg.gradle.daemon=false"


### PR DESCRIPTION
Besides a few tweaks to the Jenkins file and the pod template YAML file, there were a few tests that had to be changed. The reason is that in the new SolrCloud server in the GKE cluster, i.e. `scxa-solrcloud-fast-hs`, we’re only loading the species covered in our test datasets:
- Homo sapiens
- Mus musculus
- Arabidopsis thaliana
- Oryza sativa
- Glycine max
- Solanum Lycopersicum