### PR TITLE
Remove gene search tab

### DIFF
--- a/app/src/main/webapp/WEB-INF/jsp/tiles/local-masthead.jsp
+++ b/app/src/main/webapp/WEB-INF/jsp/tiles/local-masthead.jsp
@@ -37,7 +37,6 @@
             <nav>
                 <ul id="local-nav" class="dropdown menu float-left" data-description="navigational">
                     <li id="local-nav-home"><a href="${pageContext.request.contextPath}/home"><i class="icon icon-generic padding-right-medium" data-icon="H"></i>Home</a></li>
-                    <li id="local-nav-search"><a href="${pageContext.request.contextPath}/search"><i class="icon icon-functional padding-right-medium" data-icon="1"></i>Gene search</a></li>
                     <li id="local-nav-experiments"><a href="${pageContext.request.contextPath}/experiments"><i class="icon icon-functional padding-right-medium" data-icon="C"></i>Browse experiments</a></li>
                     <li id="local-nav-download"><a href="${pageContext.request.contextPath}/download"><i class="icon icon-common padding-right-medium" data-icon="="></i>Download</a></li>
                     <li id="local-nav-release-notes"><a href="${pageContext.request.contextPath}/release-notes.html"><i class="icon icon-generic padding-right-medium" data-icon=";"></i>Release notes</a></li>

--- a/app/src/main/webapp/WEB-INF/jsp/tiles/views/gene-search-results.jsp
+++ b/app/src/main/webapp/WEB-INF/jsp/tiles/views/gene-search-results.jsp
@@ -29,7 +29,6 @@
 
 <script>
   document.addEventListener("DOMContentLoaded", function(event) {
-    document.getElementById("local-nav-search").className += ' active';
     geneSearch.render({
       atlasUrl: '${pageContext.request.contextPath}/',
       basename: '${pageContext.request.contextPath}',


### PR DESCRIPTION
This story is about removing gene search tab from SC homepage, so the gene search results will show as an individual page without highlighting any tab.