### PR TITLE
Fix colour by category on cell plots

### DIFF
--- a/app/src/main/javascript/bundles/experiment-page/src/TSnePlotViewRoute.js
+++ b/app/src/main/javascript/bundles/experiment-page/src/TSnePlotViewRoute.js
@@ -41,9 +41,7 @@ class TSnePlotViewRoute extends React.Component {
           plotOptions: this.props.plotTypesAndOptions.tsne
         }
      ]
-
     const cellTypeValue = _first(_intersection(_map(this.props.metadata,`label`), this.props.initialCellTypeValues))
-    const search = URI(this.props.location.search).search(true)
 
     this.state = {
       selectedPlotType: plotTypeDropdown[0].plotType.toLowerCase(),
@@ -54,8 +52,15 @@ class TSnePlotViewRoute extends React.Component {
       selectedColourBy: cellTypeValue ? cellTypeValue.toLowerCase() : this.props.ks[Math.round((this.props.ks.length -1) / 2)].toString(),
       highlightClusters: [],
       experimentAccession: this.props.experimentAccession,
-      selectedColourByCategory: !isNaN(search.colourBy) ? `clusters` : `metadata`
+      selectedColourByCategory: ``
     }
+  }
+
+  componentDidMount() {
+    const search = URI(this.props.location.search).search(true)
+    this.setState({
+      selectedColourByCategory: !isNaN(search.colourBy) || !isNaN(this.state.selectedColourBy) ? `clusters` : `metadata`
+    })
   }
 
   render() {


### PR DESCRIPTION
The issue arose when we last fixed the URL routing issue where there was no colouring. (https://github.com/ebi-gene-expression-group/atlas-web-single-cell/pull/239).

The issue is when the component is initialised and there are no `cell_type` options available in the metadata, then it still selects `metadata` as `selectedColourByCategory` which is wrong. So now I have fixed it and depending on if there is a `cell_type` metadata then the category is metadata otherwise clusters which is the correct behaviour.