### PR TITLE
Add a new endpoint for organism part search

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -30,6 +30,8 @@ dependencies {
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-guava'
 
     implementation "org.cache2k:cache2k-api:${cache2kVersion}"
+    compileOnly 'org.projectlombok:lombok:1.18.22'
+    annotationProcessor 'org.projectlombok:lombok:1.18.24'
     runtimeOnly "org.cache2k:cache2k-core:${cache2kVersion}"
     implementation "org.cache2k:cache2k-spring:${cache2kVersion}"
 

--- a/app/src/main/java/uk/ac/ebi/atlas/search/GeneSearchService.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/search/GeneSearchService.java
@@ -5,9 +5,9 @@ import com.google.common.collect.ImmutableSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
-import org.springframework.util.StopWatch;
 import uk.ac.ebi.atlas.experimentpage.tsneplot.TSnePlotSettingsService;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -52,6 +52,15 @@ public class GeneSearchService {
                 geneId -> fetchClusterIDWithPreferredKAndMinPForGeneID(
                         geneSearchDao.fetchExperimentAccessionsWhereGeneIsMarker(geneId),
                         geneId));
+    }
+
+    public ImmutableSet<String> getCellIdsFromGeneIds(ImmutableSet<String> geneIds) {
+        var cellIds = new HashSet<String>();
+        for (var geneId : geneIds) {
+            var cellIdsByGeneID = geneSearchDao.fetchCellIds(geneId);
+            cellIdsByGeneID.values().forEach(cellIds::addAll);
+        }
+        return ImmutableSet.copyOf(cellIds);
     }
 
     private <T> ImmutableMap<String, T> fetchInParallel(Set<String> geneIds, Function<String, T> geneIdInfoProvider) {

--- a/app/src/main/java/uk/ac/ebi/atlas/search/JsonGeneSearchController.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/search/JsonGeneSearchController.java
@@ -148,7 +148,7 @@ public class JsonGeneSearchController extends JsonExceptionHandlingController {
         var geneQuery = geneIdSearchService.getGeneQueryByRequestParams(requestParams);
         var geneIds = geneIdSearchService.search(geneQuery);
 
-        if (geneIds.isEmpty() ||  geneIds.get().isEmpty()) {
+        if (geneIds.isEmpty()) {
             return ImmutableSet.of();
         }
 

--- a/app/src/main/java/uk/ac/ebi/atlas/search/JsonGeneSearchController.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/search/JsonGeneSearchController.java
@@ -164,11 +164,11 @@ public class JsonGeneSearchController extends JsonExceptionHandlingController {
         var geneQuery = geneIdSearchService.getGeneQueryByRequestParams(requestParams);
         var geneIds = geneIdSearchService.search(geneQuery);
 
-        if (geneIds.isPresent() && geneIds.get().isEmpty()) {
+        if (geneIds.isEmpty() ||  geneIds.get().isEmpty()) {
             return ImmutableSet.of();
         }
 
-        return organismPartSearchService.search(geneIds).orElse(ImmutableSet.of());
+        return organismPartSearchService.search(geneIds.get());
     }
 
     private List<Map.Entry<String, Map<String, List<String>>>> getMarkerGeneProfileByGeneIds(Optional<ImmutableSet<String>> geneIds) {

--- a/app/src/main/java/uk/ac/ebi/atlas/search/JsonGeneSearchController.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/search/JsonGeneSearchController.java
@@ -6,7 +6,6 @@ import com.google.common.collect.ImmutableSet;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.http.MediaType;
-import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -161,7 +160,7 @@ public class JsonGeneSearchController extends JsonExceptionHandlingController {
     @RequestMapping(value = "/json/gene-search/organism-parts",
             method = RequestMethod.GET,
             produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
-    public Set<String> getOrganismPartBySearchTerm(LinkedMultiValueMap<String, String> requestParams) {
+    public Set<String> getOrganismPartBySearchTerm(@RequestParam MultiValueMap<String, String> requestParams) {
         var geneQuery = geneIdSearchService.getGeneQueryByRequestParams(requestParams);
         var geneIds = geneIdSearchService.search(geneQuery);
 

--- a/app/src/main/java/uk/ac/ebi/atlas/search/organismpart/OrganismPartSearchDao.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/search/organismpart/OrganismPartSearchDao.java
@@ -22,7 +22,7 @@ import static uk.ac.ebi.atlas.solr.cloud.collections.SingleCellAnalyticsCollecti
 @Component
 public class OrganismPartSearchDao {
 
-    private GeneSearchDao geneSearchDao;
+    private final GeneSearchDao geneSearchDao;
 
     private final SingleCellAnalyticsCollectionProxy singleCellAnalyticsCollectionProxy;
 
@@ -38,7 +38,7 @@ public class OrganismPartSearchDao {
             return Optional.of(ImmutableSet.of());
         }
 
-        HashSet<String> cellIDs = getCellIdsFromGeneIds(geneIds);
+        var cellIDs = getCellIdsFromGeneIds(geneIds);
 
         if (cellIDs.isEmpty()) {
             return Optional.of(ImmutableSet.of());

--- a/app/src/main/java/uk/ac/ebi/atlas/search/organismpart/OrganismPartSearchDao.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/search/organismpart/OrganismPartSearchDao.java
@@ -2,9 +2,7 @@ package uk.ac.ebi.atlas.search.organismpart;
 
 import com.google.common.collect.ImmutableSet;
 import org.apache.solr.client.solrj.SolrQuery;
-import org.jetbrains.annotations.NotNull;
 import org.springframework.stereotype.Component;
-import uk.ac.ebi.atlas.search.GeneSearchDao;
 import uk.ac.ebi.atlas.solr.cloud.SolrCloudCollectionProxyFactory;
 import uk.ac.ebi.atlas.solr.cloud.TupleStreamer;
 import uk.ac.ebi.atlas.solr.cloud.collections.SingleCellAnalyticsCollectionProxy;
@@ -12,7 +10,6 @@ import uk.ac.ebi.atlas.solr.cloud.search.SolrQueryBuilder;
 import uk.ac.ebi.atlas.solr.cloud.search.streamingexpressions.decorator.UniqueStreamBuilder;
 import uk.ac.ebi.atlas.solr.cloud.search.streamingexpressions.source.SearchStreamBuilder;
 
-import java.util.HashSet;
 import java.util.Optional;
 
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
@@ -22,28 +19,14 @@ import static uk.ac.ebi.atlas.solr.cloud.collections.SingleCellAnalyticsCollecti
 @Component
 public class OrganismPartSearchDao {
 
-    private final GeneSearchDao geneSearchDao;
-
     private final SingleCellAnalyticsCollectionProxy singleCellAnalyticsCollectionProxy;
 
-    public OrganismPartSearchDao(SolrCloudCollectionProxyFactory collectionProxyFactory,
-                                 GeneSearchDao geneSearchDao) {
+    public OrganismPartSearchDao(SolrCloudCollectionProxyFactory collectionProxyFactory) {
         singleCellAnalyticsCollectionProxy =
                 collectionProxyFactory.create(SingleCellAnalyticsCollectionProxy.class);
-        this.geneSearchDao = geneSearchDao;
     }
 
-    public Optional<ImmutableSet<String>> searchOrganismPart(ImmutableSet<String> geneIds) {
-        if (geneIds.isEmpty()) {
-            return Optional.of(ImmutableSet.of());
-        }
-
-        var cellIDs = getCellIdsFromGeneIds(geneIds);
-
-        if (cellIDs.isEmpty()) {
-            return Optional.of(ImmutableSet.of());
-        }
-
+    public Optional<ImmutableSet<String>> searchOrganismPart(ImmutableSet<String> cellIDs) {
 //        Streaming query for getting the organism_part provided by set of cell IDs
 //        unique(
 //            search(scxa-analytics-v6, q=cell_id:<SET_OF_CELL_IDS>,
@@ -52,26 +35,12 @@ public class OrganismPartSearchDao {
 //            ),
 //            over="ctw_organism_part"
 //        )
-        var searchAnalyticsQueryBuilder =
-                getAnalyticsQueryBuilderByCellIds(cellIDs);
-        var uniqueOrganismPartStreamBuilder =
-                new UniqueStreamBuilder(searchAnalyticsQueryBuilder, CTW_ORGANISM_PART.name());
-
-        return getOrganismPartFromStreamQuery(uniqueOrganismPartStreamBuilder);
+        return getOrganismPartFromStreamQuery(
+                new UniqueStreamBuilder(getStreamBuilderForOrganismPartByCellIds(cellIDs), CTW_ORGANISM_PART.name()));
     }
 
-    @NotNull
-    private HashSet<String> getCellIdsFromGeneIds(ImmutableSet<String> geneIds) {
-        var cellIds = new HashSet<String>();
-        for (var geneId : geneIds) {
-            var cellIdsByGeneID = geneSearchDao.fetchCellIds(geneId);
-            cellIdsByGeneID.values().forEach(cellIds::addAll);
-        }
-        return cellIds;
-    }
-
-    private SearchStreamBuilder<SingleCellAnalyticsCollectionProxy> getAnalyticsQueryBuilderByCellIds(
-            HashSet<String> cellIDs) {
+    private SearchStreamBuilder<SingleCellAnalyticsCollectionProxy> getStreamBuilderForOrganismPartByCellIds(
+            ImmutableSet<String> cellIDs) {
         return new SearchStreamBuilder<>(
                 singleCellAnalyticsCollectionProxy,
                 new SolrQueryBuilder<SingleCellAnalyticsCollectionProxy>()

--- a/app/src/main/java/uk/ac/ebi/atlas/search/organismpart/OrganismPartSearchDao.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/search/organismpart/OrganismPartSearchDao.java
@@ -1,14 +1,92 @@
 package uk.ac.ebi.atlas.search.organismpart;
 
 import com.google.common.collect.ImmutableSet;
+import org.apache.solr.client.solrj.SolrQuery;
+import org.jetbrains.annotations.NotNull;
 import org.springframework.stereotype.Component;
+import uk.ac.ebi.atlas.search.GeneSearchDao;
+import uk.ac.ebi.atlas.solr.cloud.SolrCloudCollectionProxyFactory;
+import uk.ac.ebi.atlas.solr.cloud.TupleStreamer;
+import uk.ac.ebi.atlas.solr.cloud.collections.SingleCellAnalyticsCollectionProxy;
+import uk.ac.ebi.atlas.solr.cloud.search.SolrQueryBuilder;
+import uk.ac.ebi.atlas.solr.cloud.search.streamingexpressions.decorator.UniqueStreamBuilder;
+import uk.ac.ebi.atlas.solr.cloud.search.streamingexpressions.source.SearchStreamBuilder;
 
+import java.util.HashSet;
 import java.util.Optional;
+
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static uk.ac.ebi.atlas.solr.cloud.collections.SingleCellAnalyticsCollectionProxy.CELL_ID;
+import static uk.ac.ebi.atlas.solr.cloud.collections.SingleCellAnalyticsCollectionProxy.CTW_ORGANISM_PART;
 
 @Component
 public class OrganismPartSearchDao {
-    public Optional<ImmutableSet<String>> searchOrganismPart(String queryTerm, String category) {
 
-        return Optional.of(ImmutableSet.of());
+    private GeneSearchDao geneSearchDao;
+
+    private final SingleCellAnalyticsCollectionProxy singleCellAnalyticsCollectionProxy;
+
+    public OrganismPartSearchDao(SolrCloudCollectionProxyFactory collectionProxyFactory,
+                                 GeneSearchDao geneSearchDao) {
+        singleCellAnalyticsCollectionProxy =
+                collectionProxyFactory.create(SingleCellAnalyticsCollectionProxy.class);
+        this.geneSearchDao = geneSearchDao;
+    }
+
+    public Optional<ImmutableSet<String>> searchOrganismPart(ImmutableSet<String> geneIds) {
+        if (geneIds.isEmpty()) {
+            return Optional.of(ImmutableSet.of());
+        }
+
+        HashSet<String> cellIDs = getCellIdsFromGeneIds(geneIds);
+
+        if (cellIDs.isEmpty()) {
+            return Optional.of(ImmutableSet.of());
+        }
+
+//        Streaming query for getting the organism_part provided by set of cell IDs
+//        unique(
+//            search(scxa-analytics-v6, q=cell_id:<SET_OF_CELL_IDS>,
+//            fl="ctw_organism_part",
+//            sort="ctw_organism_part asc"
+//            ),
+//            over="ctw_organism_part"
+//        )
+        var searchAnalyticsQueryBuilder =
+                getAnalyticsQueryBuilderByCellIds(cellIDs);
+        var uniqueOrganismPartStreamBuilder =
+                new UniqueStreamBuilder(searchAnalyticsQueryBuilder, CTW_ORGANISM_PART.name());
+
+        return getOrganismPartFromStreamQuery(uniqueOrganismPartStreamBuilder);
+    }
+
+    @NotNull
+    private HashSet<String> getCellIdsFromGeneIds(ImmutableSet<String> geneIds) {
+        var cellIds = new HashSet<String>();
+        for (var geneId : geneIds) {
+            var cellIdsByGeneID = geneSearchDao.fetchCellIds(geneId);
+            cellIdsByGeneID.values().forEach(cellIds::addAll);
+        }
+        return cellIds;
+    }
+
+    private SearchStreamBuilder<SingleCellAnalyticsCollectionProxy> getAnalyticsQueryBuilderByCellIds(
+            HashSet<String> cellIDs) {
+        return new SearchStreamBuilder<>(
+                singleCellAnalyticsCollectionProxy,
+                new SolrQueryBuilder<SingleCellAnalyticsCollectionProxy>()
+                        .addQueryFieldByTerm(CELL_ID, cellIDs)
+                        .setFieldList(CTW_ORGANISM_PART)
+                        .sortBy(CTW_ORGANISM_PART, SolrQuery.ORDER.asc)
+        ).returnAllDocs();
+    }
+
+    private Optional<ImmutableSet<String>> getOrganismPartFromStreamQuery(UniqueStreamBuilder uniqueOrganismPartStreamBuilder) {
+        try (TupleStreamer tupleStreamer = TupleStreamer.of(uniqueOrganismPartStreamBuilder.build())) {
+            return Optional.of(tupleStreamer.get()
+                    .map(tuple -> tuple.getString(CTW_ORGANISM_PART.name()))
+                    .collect(toImmutableSet())
+            );
+        }
     }
 }

--- a/app/src/main/java/uk/ac/ebi/atlas/search/organismpart/OrganismPartSearchDao.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/search/organismpart/OrganismPartSearchDao.java
@@ -10,8 +10,6 @@ import uk.ac.ebi.atlas.solr.cloud.search.SolrQueryBuilder;
 import uk.ac.ebi.atlas.solr.cloud.search.streamingexpressions.decorator.UniqueStreamBuilder;
 import uk.ac.ebi.atlas.solr.cloud.search.streamingexpressions.source.SearchStreamBuilder;
 
-import java.util.Optional;
-
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static uk.ac.ebi.atlas.solr.cloud.collections.SingleCellAnalyticsCollectionProxy.CELL_ID;
 import static uk.ac.ebi.atlas.solr.cloud.collections.SingleCellAnalyticsCollectionProxy.CTW_ORGANISM_PART;
@@ -26,7 +24,7 @@ public class OrganismPartSearchDao {
                 collectionProxyFactory.create(SingleCellAnalyticsCollectionProxy.class);
     }
 
-    public Optional<ImmutableSet<String>> searchOrganismPart(ImmutableSet<String> cellIDs) {
+    public ImmutableSet<String> searchOrganismPart(ImmutableSet<String> cellIDs) {
 //        Streaming query for getting the organism_part provided by set of cell IDs
 //        unique(
 //            search(scxa-analytics-v6, q=cell_id:<SET_OF_CELL_IDS>,
@@ -50,11 +48,11 @@ public class OrganismPartSearchDao {
         ).returnAllDocs();
     }
 
-    private Optional<ImmutableSet<String>> getOrganismPartFromStreamQuery(UniqueStreamBuilder uniqueOrganismPartStreamBuilder) {
+    private ImmutableSet<String> getOrganismPartFromStreamQuery(UniqueStreamBuilder uniqueOrganismPartStreamBuilder) {
         try (TupleStreamer tupleStreamer = TupleStreamer.of(uniqueOrganismPartStreamBuilder.build())) {
-            return Optional.of(tupleStreamer.get()
+            return tupleStreamer.get()
                     .map(tuple -> tuple.getString(CTW_ORGANISM_PART.name()))
-                    .collect(toImmutableSet())
+                    .collect(toImmutableSet()
             );
         }
     }

--- a/app/src/main/java/uk/ac/ebi/atlas/search/organismpart/OrganismPartSearchDao.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/search/organismpart/OrganismPartSearchDao.java
@@ -1,0 +1,14 @@
+package uk.ac.ebi.atlas.search.organismpart;
+
+import com.google.common.collect.ImmutableSet;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@Component
+public class OrganismPartSearchDao {
+    public Optional<ImmutableSet<String>> searchOrganismPart(String queryTerm, String category) {
+
+        return Optional.of(ImmutableSet.of());
+    }
+}

--- a/app/src/main/java/uk/ac/ebi/atlas/search/organismpart/OrganismPartSearchService.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/search/organismpart/OrganismPartSearchService.java
@@ -7,8 +7,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 import uk.ac.ebi.atlas.search.GeneSearchService;
 
-import java.util.Optional;
-
 @Component
 @RequiredArgsConstructor
 public class OrganismPartSearchService {
@@ -18,18 +16,19 @@ public class OrganismPartSearchService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(OrganismPartSearchService.class);
 
-    public Optional<ImmutableSet<String>> search(Optional<ImmutableSet<String>> geneIds) {
-        if (geneIds.isEmpty() || geneIds.get().isEmpty()) {
+    public ImmutableSet<String> search(ImmutableSet<String> geneIds) {
+        if (geneIds.isEmpty()) {
             LOGGER.debug("Can't query for organism part as no gene IDs has given.");
-            return Optional.of(ImmutableSet.of());
+            return ImmutableSet.of();
         }
 
-        LOGGER.info("Searching organism parts for this gene ids: {}", geneIds.get().asList());
+        LOGGER.info("Searching organism parts for this gene ids: {}", geneIds.asList());
 
-        var cellIDs = geneSearchService.getCellIdsFromGeneIds(geneIds.get());
+        var cellIDs = geneSearchService.getCellIdsFromGeneIds(geneIds);
 
         if (cellIDs.isEmpty()) {
-            return Optional.of(ImmutableSet.of());
+            LOGGER.debug("Can't query for organism part as no cell IDs found.");
+            return ImmutableSet.of();
         }
 
         return organismPartSearchDao.searchOrganismPart(cellIDs);

--- a/app/src/main/java/uk/ac/ebi/atlas/search/organismpart/OrganismPartSearchService.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/search/organismpart/OrganismPartSearchService.java
@@ -1,0 +1,29 @@
+package uk.ac.ebi.atlas.search.organismpart;
+
+import com.google.common.collect.ImmutableSet;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+public class OrganismPartSearchService {
+
+    private final OrganismPartSearchDao organismPartSearchDao;
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(OrganismPartSearchService.class);
+
+    public Optional<ImmutableSet<String>> search(Optional<ImmutableSet<String>> geneIds) {
+        if (geneIds.isPresent() && geneIds.get().isEmpty()) {
+            LOGGER.debug("Given set of gene IDs is empty. That results with an empty set of organism part.");
+            return Optional.of(ImmutableSet.of());
+        }
+
+        LOGGER.info("Searching organism parts for this gene ids: {}", geneIds.orElseThrow().asList());
+
+        return organismPartSearchDao.searchOrganismPart(geneIds.orElseThrow());
+    }
+}

--- a/app/src/main/java/uk/ac/ebi/atlas/search/organismpart/OrganismPartSearchService.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/search/organismpart/OrganismPartSearchService.java
@@ -18,20 +18,13 @@ public class OrganismPartSearchService {
 
     public ImmutableSet<String> search(ImmutableSet<String> geneIds) {
         if (geneIds.isEmpty()) {
-            LOGGER.debug("Can't query for organism part as no gene IDs has given.");
+            LOGGER.warn("Can't query for organism part as no gene IDs has given.");
             return ImmutableSet.of();
         }
 
         LOGGER.info("Searching organism parts for this gene ids: {}", geneIds.asList());
 
-        var cellIDs = geneSearchService.getCellIdsFromGeneIds(geneIds);
-
-        if (cellIDs.isEmpty()) {
-            LOGGER.debug("Can't query for organism part as no cell IDs found.");
-            return ImmutableSet.of();
-        }
-
-        return organismPartSearchDao.searchOrganismPart(cellIDs);
+        return organismPartSearchDao.searchOrganismPart(geneSearchService.getCellIdsFromGeneIds(geneIds));
     }
 
 }

--- a/app/src/test/java/uk/ac/ebi/atlas/search/GeneSearchServiceTest.java
+++ b/app/src/test/java/uk/ac/ebi/atlas/search/GeneSearchServiceTest.java
@@ -2,6 +2,7 @@ package uk.ac.ebi.atlas.search;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -227,5 +228,27 @@ class GeneSearchServiceTest {
         assertThatExceptionOfType(RuntimeException.class).isThrownBy(
                 () -> subject.getCellIdsInExperiments(generateRandomExperimentAccession()))
                 .withCauseInstanceOf(ExecutionException.class);
+    }
+
+    @Test
+    void whenGeneIdsExistsThenReturnSetOfCellIds() {
+        var existingGeneId1 = "ExistingGeneId1";
+        var existingGeneId2 = "ExistingGeneId2";
+        var validGeneIds = ImmutableSet.of(existingGeneId1, existingGeneId2);
+        var existingCellId1 = "ExistingCellId1";
+        var existingCellId2 = "ExistingCellId2";
+        var experimentAccession = "ExperimentAccession";
+        var expectedCellIds = ImmutableSet.of(existingCellId1, existingCellId2);
+
+        when(geneSearchDaoMock.fetchCellIds(anyString()))
+                .thenReturn(
+                        Map.of(experimentAccession, List.of(existingCellId1)),
+                        Map.of(experimentAccession, List.of(existingCellId2))
+                );
+
+        var actualCellIds =
+                subject.getCellIdsFromGeneIds(validGeneIds);
+
+        assertThat(actualCellIds).containsSequence(expectedCellIds);
     }
 }

--- a/app/src/test/java/uk/ac/ebi/atlas/search/GeneSearchServiceTest.java
+++ b/app/src/test/java/uk/ac/ebi/atlas/search/GeneSearchServiceTest.java
@@ -28,6 +28,7 @@ import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
+import static uk.ac.ebi.atlas.testutils.RandomDataTestUtils.generateRandomCellId;
 import static uk.ac.ebi.atlas.testutils.RandomDataTestUtils.generateRandomEnsemblGeneId;
 import static uk.ac.ebi.atlas.testutils.RandomDataTestUtils.generateRandomExperimentAccession;
 
@@ -232,12 +233,12 @@ class GeneSearchServiceTest {
 
     @Test
     void whenGeneIdsExistsThenReturnSetOfCellIds() {
-        var existingGeneId1 = "ExistingGeneId1";
-        var existingGeneId2 = "ExistingGeneId2";
+        var existingGeneId1 = generateRandomEnsemblGeneId();
+        var existingGeneId2 = generateRandomEnsemblGeneId();
         var validGeneIds = ImmutableSet.of(existingGeneId1, existingGeneId2);
-        var existingCellId1 = "ExistingCellId1";
-        var existingCellId2 = "ExistingCellId2";
-        var experimentAccession = "ExperimentAccession";
+        var existingCellId1 = generateRandomCellId();
+        var existingCellId2 = generateRandomCellId();
+        var experimentAccession = generateRandomExperimentAccession();
         var expectedCellIds = ImmutableSet.of(existingCellId1, existingCellId2);
 
         when(geneSearchDaoMock.fetchCellIds(anyString()))

--- a/app/src/test/java/uk/ac/ebi/atlas/search/JsonGeneSearchControllerIT.java
+++ b/app/src/test/java/uk/ac/ebi/atlas/search/JsonGeneSearchControllerIT.java
@@ -189,8 +189,8 @@ class JsonGeneSearchControllerIT {
                 .thenReturn(geneQuery);
         when(geneIdSearchServiceMock.search(geneQuery))
                 .thenReturn(Optional.of(geneIdsFromService));
-        when(organismPartSearchServiceMock.search(Optional.of(geneIdsFromService)))
-                .thenReturn(Optional.of(ImmutableSet.of()));
+        when(organismPartSearchServiceMock.search(geneIdsFromService))
+                .thenReturn(ImmutableSet.of());
 
         var emptyOrganismPartSet = subject.getOrganismPartBySearchTerm(requestParams);
 
@@ -212,13 +212,11 @@ class JsonGeneSearchControllerIT {
                 .thenReturn(geneQuery);
         when(geneIdSearchServiceMock.search(geneQuery))
                 .thenReturn(Optional.of(geneIdsFromService));
-        when(organismPartSearchServiceMock.search(Optional.of(geneIdsFromService)))
-                .thenReturn(Optional.of(ImmutableSet.of(expectedOrganismPart)));
+        when(organismPartSearchServiceMock.search(geneIdsFromService))
+                .thenReturn(ImmutableSet.of(expectedOrganismPart));
 
         var actualOrganismParts = subject.getOrganismPartBySearchTerm(requestParams);
 
-        assertThat(actualOrganismParts).isNotEmpty();
-        assertThat(actualOrganismParts).hasSize(1);
-        assertThat(actualOrganismParts).contains(expectedOrganismPart);
+        assertThat(actualOrganismParts).containsExactly(expectedOrganismPart);
     }
 }

--- a/app/src/test/java/uk/ac/ebi/atlas/search/JsonGeneSearchControllerIT.java
+++ b/app/src/test/java/uk/ac/ebi/atlas/search/JsonGeneSearchControllerIT.java
@@ -173,6 +173,8 @@ class JsonGeneSearchControllerIT {
                 .thenReturn(geneQuery);
         when(geneIdSearchServiceMock.search(geneQuery))
                 .thenReturn(Optional.of(ImmutableSet.of()));
+        when(organismPartSearchServiceMock.search(ImmutableSet.of()))
+                .thenReturn(ImmutableSet.of());
 
         var emptyOrganismPartSet = subject.getOrganismPartBySearchTerm(requestParams);
 

--- a/app/src/test/java/uk/ac/ebi/atlas/search/JsonGeneSearchControllerWIT.java
+++ b/app/src/test/java/uk/ac/ebi/atlas/search/JsonGeneSearchControllerWIT.java
@@ -29,6 +29,7 @@ import javax.inject.Inject;
 import javax.sql.DataSource;
 
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasSize;
@@ -198,7 +199,7 @@ class JsonGeneSearchControllerWIT {
                 .andExpect(jsonPath("$.results[0].facets[0].description", isA(String.class)))
                 .andExpect(jsonPath("$.checkboxFacetGroups", contains("Marker genes", "Species")));
     }
-      
+
     @Test
     void speciesParamCanAppearBeforeGeneQuery() throws Exception {
         this.mockMvc.perform(get("/json/search").param("species", "homo sapiens").param("symbol", "aspm"))
@@ -234,5 +235,39 @@ class JsonGeneSearchControllerWIT {
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8))
                 .andExpect(content().string("false"));
+    }
+
+    @Test
+    void whenSearchForOrganismPartWithEmptyValueReturnsError() throws Exception {
+        final String emptyOrganismPartSearchTerm = "";
+        final String expectedMessage = "{\"error\":\"Error parsing query\"}\n";
+        this.mockMvc.perform(get("/json/gene-search/organism-parts").param("q", emptyOrganismPartSearchTerm))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8))
+                .andExpect(content().string(expectedMessage));
+    }
+
+    @Test
+    void whenSearchTermNotExistsInDBThenReturnsEmptySet() throws Exception {
+        var geneNotPartOfAnyExperiments = "ENSRNA049444660";
+
+        this.mockMvc.perform(get("/json/gene-search/organism-parts").param("ensgene", geneNotPartOfAnyExperiments))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8))
+                .andExpect(jsonPath("$", hasSize(equalTo(0))));
+    }
+
+    @Test
+    void whenSearchTermExistsInDBThenReturnsSetOfOrganismParts() throws Exception {
+        var shouldBeGeneThatPartOfExperiments =
+                jdbcTestUtils.fetchRandomGeneFromSingleCellExperiment("E-CURD-4");
+
+        var expectedOrganismParts = "root";
+
+        this.mockMvc.perform(get("/json/gene-search/organism-parts").param("ensgene", shouldBeGeneThatPartOfExperiments))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8))
+                .andExpect(jsonPath("$", hasSize(equalTo(1))))
+                .andExpect(jsonPath("$", containsInAnyOrder(expectedOrganismParts)));
     }
 }

--- a/app/src/test/java/uk/ac/ebi/atlas/search/organismpart/OrganismPartSearchDaoIT.java
+++ b/app/src/test/java/uk/ac/ebi/atlas/search/organismpart/OrganismPartSearchDaoIT.java
@@ -1,0 +1,38 @@
+package uk.ac.ebi.atlas.search.organismpart;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.context.web.WebAppConfiguration;
+import uk.ac.ebi.atlas.configuration.TestConfig;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.ac.ebi.atlas.solr.bioentities.BioentityPropertyName.SYMBOL;
+
+@WebAppConfiguration
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = TestConfig.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class OrganismPartSearchDaoIT {
+
+    private OrganismPartSearchDao subject;
+
+    @BeforeEach
+    void setup() {
+        subject = new OrganismPartSearchDao();
+    }
+
+    @Test
+    void whenEmptySearchTextProvidedReturnEmptyOptional() {
+        var queryTerm = "";
+        var category = SYMBOL.name;
+
+        var organismPart = subject.searchOrganismPart(queryTerm, category);
+
+        assertThat(organismPart.isPresent()).isTrue();
+        assertThat(organismPart.get()).isEmpty();
+    }
+}

--- a/app/src/test/java/uk/ac/ebi/atlas/search/organismpart/OrganismPartSearchDaoIT.java
+++ b/app/src/test/java/uk/ac/ebi/atlas/search/organismpart/OrganismPartSearchDaoIT.java
@@ -13,7 +13,6 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.context.web.WebAppConfiguration;
 import uk.ac.ebi.atlas.configuration.TestConfig;
-import uk.ac.ebi.atlas.search.GeneSearchDao;
 import uk.ac.ebi.atlas.solr.cloud.SolrCloudCollectionProxyFactory;
 import uk.ac.ebi.atlas.testutils.JdbcUtils;
 
@@ -39,17 +38,13 @@ public class OrganismPartSearchDaoIT {
     @Inject
     private SolrCloudCollectionProxyFactory collectionProxyFactory;
 
-    @Inject
-    private GeneSearchDao geneSearchDao;
-
     private OrganismPartSearchDao subject;
 
     @BeforeAll
     void populateDatabaseTables() {
         var populator = new ResourceDatabasePopulator();
         populator.addScripts(
-                new ClassPathResource("fixtures/scxa_analytics.sql"),
-                new ClassPathResource("fixtures/experiment.sql")
+                new ClassPathResource("fixtures/scxa_analytics.sql")
         );
 
         populator.execute(dataSource);
@@ -59,7 +54,6 @@ public class OrganismPartSearchDaoIT {
     void cleanDatabaseTables() {
         var populator = new ResourceDatabasePopulator();
         populator.addScripts(
-                new ClassPathResource("fixtures/experiment-delete.sql"),
                 new ClassPathResource("fixtures/scxa_analytics-delete.sql")
         );
         populator.execute(dataSource);
@@ -67,38 +61,38 @@ public class OrganismPartSearchDaoIT {
 
     @BeforeEach
     void setup() {
-        subject = new OrganismPartSearchDao(collectionProxyFactory, geneSearchDao);
+        subject = new OrganismPartSearchDao(collectionProxyFactory);
     }
 
     @Test
-    void whenEmptySetOfGeneIDsProvidedReturnEmptyOptional() {
-        ImmutableSet<String> geneIds = ImmutableSet.of();
+    void whenEmptySetOfCellIDsProvidedReturnEmptyOptional() {
+        ImmutableSet<String> cellIDs = ImmutableSet.of();
 
-        var organismParts = subject.searchOrganismPart(geneIds);
+        var organismParts = subject.searchOrganismPart(cellIDs);
 
         assertThat(organismParts.isPresent()).isTrue();
         assertThat(organismParts.get()).isEmpty();
     }
 
     @Test
-    void whenSetOfInvalidGeneIdsProvidedReturnSetOfOrganismPart() {
-        var geneIds =
-                ImmutableSet.of("invalid-geneId-1", "invalid-geneId-2", "invalid-geneId-3");
+    void whenSetOfInvalidCellIdsProvidedReturnSetOfOrganismPart() {
+        var cellIDs =
+                ImmutableSet.of("invalid-cellID-1", "invalid-cellID-2", "invalid-cellID-3");
 
-        var organismParts = subject.searchOrganismPart(geneIds);
+        var organismParts = subject.searchOrganismPart(cellIDs);
 
         assertThat(organismParts.isPresent()).isTrue();
         assertThat(organismParts.get()).isEmpty();
     }
 
     @Test
-    void whenSetOfValidGeneIdsProvidedReturnSetOfOrganismPart() {
-        final List<String> randomListOfGeneIds = jdbcUtils.fetchRandomListOfGeneIds(10);
-        var geneIds =
+    void whenSetOfValidCellIdsProvidedReturnSetOfOrganismPart() {
+        final List<String> randomListOfCellIDs = jdbcUtils.fetchRandomListOfCells(10);
+        var cellIDs =
                 ImmutableSet.copyOf(
-                        new HashSet<>(randomListOfGeneIds));
+                        new HashSet<>(randomListOfCellIDs));
 
-        var organismParts = subject.searchOrganismPart(geneIds);
+        var organismParts = subject.searchOrganismPart(cellIDs);
 
         assertThat(organismParts.isPresent()).isTrue();
         assertThat(organismParts.get().size()).isGreaterThan(0);

--- a/app/src/test/java/uk/ac/ebi/atlas/search/organismpart/OrganismPartSearchDaoIT.java
+++ b/app/src/test/java/uk/ac/ebi/atlas/search/organismpart/OrganismPartSearchDaoIT.java
@@ -1,16 +1,28 @@
 package uk.ac.ebi.atlas.search.organismpart;
 
+import com.google.common.collect.ImmutableSet;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.jdbc.datasource.init.ResourceDatabasePopulator;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.context.web.WebAppConfiguration;
 import uk.ac.ebi.atlas.configuration.TestConfig;
+import uk.ac.ebi.atlas.search.GeneSearchDao;
+import uk.ac.ebi.atlas.solr.cloud.SolrCloudCollectionProxyFactory;
+import uk.ac.ebi.atlas.testutils.JdbcUtils;
+
+import javax.inject.Inject;
+import javax.sql.DataSource;
+import java.util.HashSet;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static uk.ac.ebi.atlas.solr.bioentities.BioentityPropertyName.SYMBOL;
 
 @WebAppConfiguration
 @ExtendWith(SpringExtension.class)
@@ -18,21 +30,77 @@ import static uk.ac.ebi.atlas.solr.bioentities.BioentityPropertyName.SYMBOL;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class OrganismPartSearchDaoIT {
 
+    @Inject
+    private JdbcUtils jdbcUtils;
+
+    @Inject
+    private DataSource dataSource;
+
+    @Inject
+    private SolrCloudCollectionProxyFactory collectionProxyFactory;
+
+    @Inject
+    private GeneSearchDao geneSearchDao;
+
     private OrganismPartSearchDao subject;
+
+    @BeforeAll
+    void populateDatabaseTables() {
+        var populator = new ResourceDatabasePopulator();
+        populator.addScripts(
+                new ClassPathResource("fixtures/scxa_analytics.sql"),
+                new ClassPathResource("fixtures/experiment.sql")
+        );
+
+        populator.execute(dataSource);
+    }
+
+    @AfterAll
+    void cleanDatabaseTables() {
+        var populator = new ResourceDatabasePopulator();
+        populator.addScripts(
+                new ClassPathResource("fixtures/experiment-delete.sql"),
+                new ClassPathResource("fixtures/scxa_analytics-delete.sql")
+        );
+        populator.execute(dataSource);
+    }
 
     @BeforeEach
     void setup() {
-        subject = new OrganismPartSearchDao();
+        subject = new OrganismPartSearchDao(collectionProxyFactory, geneSearchDao);
     }
 
     @Test
-    void whenEmptySearchTextProvidedReturnEmptyOptional() {
-        var queryTerm = "";
-        var category = SYMBOL.name;
+    void whenEmptySetOfGeneIDsProvidedReturnEmptyOptional() {
+        ImmutableSet<String> geneIds = ImmutableSet.of();
 
-        var organismPart = subject.searchOrganismPart(queryTerm, category);
+        var organismParts = subject.searchOrganismPart(geneIds);
 
-        assertThat(organismPart.isPresent()).isTrue();
-        assertThat(organismPart.get()).isEmpty();
+        assertThat(organismParts.isPresent()).isTrue();
+        assertThat(organismParts.get()).isEmpty();
+    }
+
+    @Test
+    void whenSetOfInvalidGeneIdsProvidedReturnSetOfOrganismPart() {
+        ImmutableSet<String> geneIds =
+                ImmutableSet.of("invalid-geneId-1", "invalid-geneId-2", "invalid-geneId-3");
+
+        var organismParts = subject.searchOrganismPart(geneIds);
+
+        assertThat(organismParts.isPresent()).isTrue();
+        assertThat(organismParts.get()).isEmpty();
+    }
+
+    @Test
+    void whenSetOfValidGeneIdsProvidedReturnSetOfOrganismPart() {
+        final List<String> randomListOfGeneIds = jdbcUtils.fetchRandomListOfGeneIds(10);
+        ImmutableSet<String> geneIds =
+                ImmutableSet.copyOf(
+                        new HashSet<String>(randomListOfGeneIds));
+
+        var organismParts = subject.searchOrganismPart(geneIds);
+
+        assertThat(organismParts.isPresent()).isTrue();
+        assertThat(organismParts.get().size()).isGreaterThan(0);
     }
 }

--- a/app/src/test/java/uk/ac/ebi/atlas/search/organismpart/OrganismPartSearchDaoIT.java
+++ b/app/src/test/java/uk/ac/ebi/atlas/search/organismpart/OrganismPartSearchDaoIT.java
@@ -65,28 +65,26 @@ public class OrganismPartSearchDaoIT {
     }
 
     @Test
-    void whenEmptySetOfCellIDsProvidedReturnEmptyOptional() {
+    void whenEmptySetOfCellIDsProvidedReturnEmptySetOfOrganismPart() {
         ImmutableSet<String> cellIDs = ImmutableSet.of();
 
         var organismParts = subject.searchOrganismPart(cellIDs);
 
-        assertThat(organismParts.isPresent()).isTrue();
-        assertThat(organismParts.get()).isEmpty();
+        assertThat(organismParts).isEmpty();
     }
 
     @Test
-    void whenSetOfInvalidCellIdsProvidedReturnSetOfOrganismPart() {
+    void whenInvalidCellIdsProvidedReturnEmptySetOfOrganismPart() {
         var cellIDs =
                 ImmutableSet.of("invalid-cellID-1", "invalid-cellID-2", "invalid-cellID-3");
 
         var organismParts = subject.searchOrganismPart(cellIDs);
 
-        assertThat(organismParts.isPresent()).isTrue();
-        assertThat(organismParts.get()).isEmpty();
+        assertThat(organismParts).isEmpty();
     }
 
     @Test
-    void whenSetOfValidCellIdsProvidedReturnSetOfOrganismPart() {
+    void whenValidCellIdsProvidedReturnSetOfOrganismPart() {
         final List<String> randomListOfCellIDs = jdbcUtils.fetchRandomListOfCells(10);
         var cellIDs =
                 ImmutableSet.copyOf(
@@ -94,7 +92,6 @@ public class OrganismPartSearchDaoIT {
 
         var organismParts = subject.searchOrganismPart(cellIDs);
 
-        assertThat(organismParts.isPresent()).isTrue();
-        assertThat(organismParts.get().size()).isGreaterThan(0);
+        assertThat(organismParts.size()).isGreaterThan(0);
     }
 }

--- a/app/src/test/java/uk/ac/ebi/atlas/search/organismpart/OrganismPartSearchDaoIT.java
+++ b/app/src/test/java/uk/ac/ebi/atlas/search/organismpart/OrganismPartSearchDaoIT.java
@@ -82,7 +82,7 @@ public class OrganismPartSearchDaoIT {
 
     @Test
     void whenSetOfInvalidGeneIdsProvidedReturnSetOfOrganismPart() {
-        ImmutableSet<String> geneIds =
+        var geneIds =
                 ImmutableSet.of("invalid-geneId-1", "invalid-geneId-2", "invalid-geneId-3");
 
         var organismParts = subject.searchOrganismPart(geneIds);
@@ -94,9 +94,9 @@ public class OrganismPartSearchDaoIT {
     @Test
     void whenSetOfValidGeneIdsProvidedReturnSetOfOrganismPart() {
         final List<String> randomListOfGeneIds = jdbcUtils.fetchRandomListOfGeneIds(10);
-        ImmutableSet<String> geneIds =
+        var geneIds =
                 ImmutableSet.copyOf(
-                        new HashSet<String>(randomListOfGeneIds));
+                        new HashSet<>(randomListOfGeneIds));
 
         var organismParts = subject.searchOrganismPart(geneIds);
 

--- a/app/src/test/java/uk/ac/ebi/atlas/search/organismpart/OrganismPartSearchServiceTest.java
+++ b/app/src/test/java/uk/ac/ebi/atlas/search/organismpart/OrganismPartSearchServiceTest.java
@@ -1,0 +1,71 @@
+package uk.ac.ebi.atlas.search.organismpart;
+
+import com.google.common.collect.ImmutableSet;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class OrganismPartSearchServiceTest {
+
+    @Mock
+    private OrganismPartSearchDao organismPartSearchDao;
+
+    private OrganismPartSearchService subject;
+
+    @BeforeEach
+    void setup() {
+        subject = new OrganismPartSearchService(organismPartSearchDao);
+    }
+
+    @Test
+    void whenEmptySetOfGeneIdsProvidedReturnEmptyOptional() {
+        Optional<ImmutableSet<String>> emptySetOfGeneIds = Optional.of(ImmutableSet.of());
+
+        var emptySetOfOrganismParts = subject.search(emptySetOfGeneIds);
+
+        assertThat(emptySetOfOrganismParts.isPresent()).isTrue();
+        assertThat(emptySetOfOrganismParts.get()).hasSize(0);
+    }
+
+    @Test
+    void whenNonExistentGeneIdsGivenReturnEmptyOptional() {
+        var nonExistentGeneId = "nonExistentGeneId";
+        var emptySetOfGeneIds = Optional.of(ImmutableSet.of(nonExistentGeneId));
+
+        when(organismPartSearchDao.searchOrganismPart(emptySetOfGeneIds.get()))
+                .thenReturn(Optional.of(ImmutableSet.of()));
+
+        var emptySetOfOrganismParts = subject.search(emptySetOfGeneIds);
+
+        assertThat(emptySetOfOrganismParts.isPresent()).isTrue();
+        assertThat(emptySetOfOrganismParts.get()).hasSize(0);
+    }
+
+    @Test
+    void whenValidSetOfGeneIdsGivenReturnSetOfOrganismParts() {
+        var existingGeneId1 = "ExistingGeneId1";
+        var existingGeneId2 = "ExistingGeneId2";
+        var validGeneIds = Optional.of(ImmutableSet.of(existingGeneId1, existingGeneId2));
+        var expectedOrganismPart = "primary visual cortex";
+
+        when(organismPartSearchDao.searchOrganismPart(validGeneIds.get()))
+                .thenReturn(Optional.of(ImmutableSet.of(expectedOrganismPart)));
+
+        var actualSetOfOrganismParts = subject.search(validGeneIds);
+
+        assertThat(actualSetOfOrganismParts.isPresent()).isTrue();
+        assertThat(actualSetOfOrganismParts.get()).hasSize(1);
+        assertThat(actualSetOfOrganismParts.get()).contains(expectedOrganismPart);
+    }
+}

--- a/app/src/test/java/uk/ac/ebi/atlas/search/organismpart/OrganismPartSearchServiceTest.java
+++ b/app/src/test/java/uk/ac/ebi/atlas/search/organismpart/OrganismPartSearchServiceTest.java
@@ -10,8 +10,6 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import uk.ac.ebi.atlas.search.GeneSearchService;
 
-import java.util.Optional;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
@@ -33,47 +31,45 @@ public class OrganismPartSearchServiceTest {
     }
 
     @Test
-    void whenEmptySetOfGeneIdsProvidedReturnEmptyOptional() {
-        Optional<ImmutableSet<String>> emptySetOfGeneIds = Optional.of(ImmutableSet.of());
+    void whenEmptySetOfGeneIdsProvidedReturnEmptySetOfOrganismPart() {
+        ImmutableSet<String> emptySetOfGeneIds = ImmutableSet.of();
 
         var emptySetOfOrganismParts = subject.search(emptySetOfGeneIds);
 
-        assertThat(emptySetOfOrganismParts).isPresent();
-        assertThat(emptySetOfOrganismParts.get()).hasSize(0);
+        assertThat(emptySetOfOrganismParts).isEmpty();
     }
 
     @Test
-    void whenNonExistentGeneIdsGivenReturnEmptyOptional() {
+    void whenNonExistentGeneIdsGivenReturnEmptySetOfOrganismPart() {
         var nonExistentGeneId = "nonExistentGeneId";
-        var emptySetOfGeneIds = Optional.of(ImmutableSet.of(nonExistentGeneId));
+        var emptySetOfGeneIds = ImmutableSet.of(nonExistentGeneId);
 
-        when(geneSearchService.getCellIdsFromGeneIds(emptySetOfGeneIds.get()))
+        when(geneSearchService.getCellIdsFromGeneIds(emptySetOfGeneIds))
                 .thenReturn(ImmutableSet.of());
 
         var emptySetOfOrganismParts = subject.search(emptySetOfGeneIds);
 
-        assertThat(emptySetOfOrganismParts).isPresent();
-        assertThat(emptySetOfOrganismParts.get()).hasSize(0);
+        assertThat(emptySetOfOrganismParts).isEmpty();
     }
 
     @Test
-    void whenValidSetOfGeneIdsGivenReturnSetOfOrganismParts() {
+    void whenValidGeneIdsGivenReturnSetOfOrganismParts() {
         var existingGeneId1 = "ExistingGeneId1";
         var existingGeneId2 = "ExistingGeneId2";
-        var validGeneIds = Optional.of(ImmutableSet.of(existingGeneId1, existingGeneId2));
+        var validGeneIds = ImmutableSet.of(existingGeneId1, existingGeneId2);
         var existingCellId1 = "ExistingCellId1";
         var existingCellId2 = "ExistingCellId2";
         var validCellIds = ImmutableSet.of(existingCellId1, existingCellId2);
 
         var expectedOrganismPart = "primary visual cortex";
 
-        when(geneSearchService.getCellIdsFromGeneIds(validGeneIds.get()))
+        when(geneSearchService.getCellIdsFromGeneIds(validGeneIds))
                 .thenReturn(validCellIds);
         when(organismPartSearchDao.searchOrganismPart(validCellIds))
-                .thenReturn(Optional.of(ImmutableSet.of(expectedOrganismPart)));
+                .thenReturn(ImmutableSet.of(expectedOrganismPart));
 
         var actualSetOfOrganismParts = subject.search(validGeneIds);
 
-        assertThat(actualSetOfOrganismParts).contains(ImmutableSet.of(expectedOrganismPart));
+        assertThat(actualSetOfOrganismParts).contains(expectedOrganismPart);
     }
 }

--- a/app/src/test/java/uk/ac/ebi/atlas/search/organismpart/OrganismPartSearchServiceTest.java
+++ b/app/src/test/java/uk/ac/ebi/atlas/search/organismpart/OrganismPartSearchServiceTest.java
@@ -46,10 +46,13 @@ public class OrganismPartSearchServiceTest {
 
         when(geneSearchService.getCellIdsFromGeneIds(emptySetOfGeneIds))
                 .thenReturn(ImmutableSet.of());
+        when(organismPartSearchDao.searchOrganismPart(ImmutableSet.of()))
+                .thenReturn(ImmutableSet.of());
 
         var emptySetOfOrganismParts = subject.search(emptySetOfGeneIds);
 
         assertThat(emptySetOfOrganismParts).isEmpty();
+
     }
 
     @Test


### PR DESCRIPTION
Changes:

- Add an endpoint for searching organism parts by search term
- Endpoint: `/json/search/organism-parts`
- Associated pull requests in 'atlas-web-core': 
  - https://github.com/ebi-gene-expression-group/atlas-web-core/pull/114
  -  https://github.com/ebi-gene-expression-group/atlas-web-core/pull/117