### PR TITLE
Add search box and species drop-down to cell type wheel

### DIFF
--- a/app/src/main/javascript/bundles/cell-type-wheel-heatmap/package.json
+++ b/app/src/main/javascript/bundles/cell-type-wheel-heatmap/package.json
@@ -13,7 +13,7 @@
   ],
   "license": "Apache-2.0",
   "dependencies": {
-    "@ebi-gene-expression-group/scxa-cell-type-wheel-heatmap": "^1.3.0",
+    "@ebi-gene-expression-group/scxa-cell-type-wheel-heatmap": "^1.3.2",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
   },

--- a/app/src/main/javascript/bundles/cell-type-wheel-heatmap/package.json
+++ b/app/src/main/javascript/bundles/cell-type-wheel-heatmap/package.json
@@ -13,12 +13,12 @@
   ],
   "license": "Apache-2.0",
   "dependencies": {
-    "@ebi-gene-expression-group/scxa-cell-type-wheel-heatmap": "^1.2.0",
+    "@ebi-gene-expression-group/scxa-cell-type-wheel-heatmap": "^1.3.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
   },
   "devDependencies": {
-    "@ebi-gene-expression-group/eslint-config": "^3.3.0",
+    "@ebi-gene-expression-group/eslint-config": "^3.5.1",
     "eslint": "^8.17.0"
   }
 }

--- a/app/src/main/javascript/bundles/experiment-page/package.json
+++ b/app/src/main/javascript/bundles/experiment-page/package.json
@@ -10,7 +10,7 @@
     "@ebi-gene-expression-group/atlas-bioentity-information": "^2.1.4",
     "@ebi-gene-expression-group/expression-atlas-disclaimers": "^1.4.0",
     "@ebi-gene-expression-group/organ-anatomogram": "1.1.0-beta1",
-    "@ebi-gene-expression-group/scxa-marker-gene-heatmap": "^2.5.0",
+    "@ebi-gene-expression-group/scxa-marker-gene-heatmap": "^2.5.1",
     "@ebi-gene-expression-group/scxa-tsne-plot": "^6.2.0",
     "linkifyjs": "^2.1.9",
     "lodash": "^4.17.20",

--- a/app/src/main/javascript/bundles/experiment-page/package.json
+++ b/app/src/main/javascript/bundles/experiment-page/package.json
@@ -9,8 +9,8 @@
   "dependencies": {
     "@ebi-gene-expression-group/atlas-bioentity-information": "^2.1.4",
     "@ebi-gene-expression-group/expression-atlas-disclaimers": "^1.4.0",
-    "@ebi-gene-expression-group/organ-anatomogram": "1.0.0",
-    "@ebi-gene-expression-group/scxa-marker-gene-heatmap": "^2.4.0",
+    "@ebi-gene-expression-group/organ-anatomogram": "1.1.0-beta1",
+    "@ebi-gene-expression-group/scxa-marker-gene-heatmap": "^2.5.0",
     "@ebi-gene-expression-group/scxa-tsne-plot": "^6.2.0",
     "linkifyjs": "^2.1.9",
     "lodash": "^4.17.20",

--- a/app/src/main/javascript/package.json
+++ b/app/src/main/javascript/package.json
@@ -17,7 +17,7 @@
     "@ebi-gene-expression-group/atlas-feedback-form": "^1.4.1",
     "@ebi-gene-expression-group/atlas-homepage-cards": "^2.5.3",
     "@ebi-gene-expression-group/atlas-react-fetch-loader": "^3.9.0",
-    "@ebi-gene-expression-group/scxa-cell-type-wheel-heatmap": "^1.2.0",
+    "@ebi-gene-expression-group/scxa-cell-type-wheel-heatmap": "^1.3.0",
     "@ebi-gene-expression-group/scxa-gene-search-form": "^2.0.0",
     "expression-atlas-autocomplete": "^3.2.0",
     "lodash": "^4.17.20",

--- a/app/src/main/javascript/package.json
+++ b/app/src/main/javascript/package.json
@@ -17,7 +17,7 @@
     "@ebi-gene-expression-group/atlas-feedback-form": "^1.4.1",
     "@ebi-gene-expression-group/atlas-homepage-cards": "^2.5.3",
     "@ebi-gene-expression-group/atlas-react-fetch-loader": "^3.9.0",
-    "@ebi-gene-expression-group/scxa-cell-type-wheel-heatmap": "^1.3.0",
+    "@ebi-gene-expression-group/scxa-cell-type-wheel-heatmap": "^1.3.2",
     "@ebi-gene-expression-group/scxa-gene-search-form": "^2.0.0",
     "expression-atlas-autocomplete": "^3.2.0",
     "lodash": "^4.17.20",

--- a/app/src/main/webapp/resources/css/atlas.css
+++ b/app/src/main/webapp/resources/css/atlas.css
@@ -32,7 +32,7 @@ hr {
 }
 
 /* Override EBI VF styles for components that use React-Select */
-#gene-search input, #experiment-page input, #search-form input {
+#gene-search input, #experiment-page input, #cellTypeWheelHeatmap input, #search-form input {
     height: unset;
     box-shadow: none;
     margin: 0;


### PR DESCRIPTION
Changes:

- Using the updated `@ebi-gene-expression-group/scxa-cell-type-wheel-heatmap` component. The search box field and the species drop-down have been added to this component.
- The height of the search box has been fixed, too.