### PR TITLE
Fix flaky GeneIdSearchServiceTest

### DIFF
--- a/app/src/main/java/uk/ac/ebi/atlas/search/geneids/GeneQuery.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/search/geneids/GeneQuery.java
@@ -30,7 +30,7 @@ public abstract class GeneQuery {
     }
 
     public static GeneQuery create(String queryTerm, BioentityPropertyName category, Species species) {
-        return create(queryTerm, Optional.of(category), Optional.of(species));
+        return create(queryTerm, Optional.ofNullable(category), Optional.of(species));
     }
 
     @SuppressWarnings("OptionalUsedAsFieldOrParameterType")


### PR DESCRIPTION
Changes:

- Use the latest atlas-web-core module that removes UNKNOWN from BioentityPropertyName's values
- Associated pull requests in `atlas-web-core`: https://github.com/ebi-gene-expression-group/atlas-web-core/pull/119