### PR TITLE
Improve development Docker environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ### TL;DR
 ```bash
-./docker/prepare-dev-environment/gradle-ro-dep-cache/run.sh -l gradle-ro-dep-cache.log && \
+./docker/prepare-dev-environment/gradle-cache/run.sh -l gradle-cache.log && \
 ./docker/prepare-dev-environment/volumes/run.sh -l volumes.log && \
 ./docker/prepare-dev-environment/postgres/run.sh -l pg-anndata.log && \
 SCHEMA_VERSION=18 docker-compose -f ./docker/docker-compose-postgres.yml down && \
@@ -33,6 +33,7 @@ The full list of volumes is:
 - `scxa-atlas-data-bioentity-properties`
 - `scxa-atlas-data-scxa`
 - `scxa-atlas-data-scxa-expdesign`
+- `scxa-gradle-wrapper-dists`
 - `scxa-gradle-ro-dep-cache`
 - `scxa-postgres-11-pgdata-18`
 - `scxa-postgres-11-pgdata-latest`
@@ -63,7 +64,7 @@ git submodule update --remote
 To speed up builds and tests it is strongly encouraged to create a Docker volume to back a [Gradle read-only dependency
 cache](https://docs.gradle.org/current/userguide/dependency_resolution.html#sub:ephemeral-ci-cache).
 ```bash
-./docker/prepare-dev-environment/gradle-ro-dep-cache/run.sh -l gradle-ro-dep-cache.log
+./docker/prepare-dev-environment/gradle-cache/run.sh -l gradle-cache.log
 ```
 
 ### Prepare volumes

--- a/docker/dev.env
+++ b/docker/dev.env
@@ -1,3 +1,4 @@
+GRADLE_WRAPPER_DISTS_VOL_NAME=scxa-gradle-wrapper-dists
 GRADLE_RO_DEP_CACHE_VOL_NAME=scxa-gradle-ro-dep-cache
 ATLAS_DATA_BIOENTITY_PROPERTIES_VOL_NAME=scxa-atlas-data-bioentity-properties
 ATLAS_DATA_SCXA_VOL_NAME=scxa-atlas-data-scxa

--- a/docker/docker-compose-gradle.yml
+++ b/docker/docker-compose-gradle.yml
@@ -11,6 +11,7 @@ services:
     working_dir: /root/project
     volumes:
       - ..:/root/project
+      - gradle-wrapper-dists:/root/.gradle/wrapper/dists
       - gradle-ro-dep-cache:/gradle-ro-dep-cache:ro
       - bioentity-properties:/atlas-data/bioentity_properties:ro
       - scxa-data:/atlas-data/scxa:ro
@@ -47,6 +48,8 @@ services:
         ./gradlew :app:jacocoTestReport
 
 volumes:
+  gradle-wrapper-dists:
+    name: ${GRADLE_WRAPPER_DISTS_VOL_NAME}
   gradle-ro-dep-cache:
     name: ${GRADLE_RO_DEP_CACHE_VOL_NAME}
   bioentity-properties:

--- a/docker/docker-compose-postgres-test.yml
+++ b/docker/docker-compose-postgres-test.yml
@@ -8,6 +8,8 @@ services:
       - atlas-test-net
     restart: always
     command: -c max_wal_size=1GB
+    ports:
+      - "5432:5432"
     environment:
       POSTGRES_HOST: ${POSTGRES_HOST}
       POSTGRES_USER: ${POSTGRES_USER}

--- a/docker/prepare-dev-environment/gradle-cache/Dockerfile
+++ b/docker/prepare-dev-environment/gradle-cache/Dockerfile
@@ -6,6 +6,7 @@ RUN apt -y -qq install git openjdk-11-jdk rsync
 RUN git clone --recurse-submodules --depth 1 https://github.com/ebi-gene-expression-group/atlas-web-single-cell.git /root/atlas-web-single-cell
 WORKDIR /root/atlas-web-single-cell
 
+VOLUME /gradle-wrapper-dists
 VOLUME /gradle-ro-dep-cache
 ENV JAVA_TOOL_OPTIONS="-Dfile.encoding=UTF8"
 

--- a/docker/prepare-dev-environment/gradle-cache/docker-entrypoint.sh
+++ b/docker/prepare-dev-environment/gradle-cache/docker-entrypoint.sh
@@ -6,4 +6,5 @@
 
 printf '\n%b\n\n' "🙈 Ignore any errors above: our only goal is to have Gradle dependencies in the local cache."
 
+rsync -av /root/.gradle/wrapper/dists/* /gradle-wrapper-dists/
 rsync -av --exclude=*.lock --exclude=gc.properties /root/.gradle/caches/modules-2 /gradle-ro-dep-cache/

--- a/docker/prepare-dev-environment/gradle-cache/run.sh
+++ b/docker/prepare-dev-environment/gradle-cache/run.sh
@@ -2,6 +2,7 @@
 set -e
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
+# GRADLE_DISTS_VOL_NAME
 # GRADLE_RO_DEP_CACHE_VOL_NAME
 source ${SCRIPT_DIR}/../../dev.env
 # print_stage_name
@@ -11,7 +12,8 @@ source ${SCRIPT_DIR}/../utils.sh
 
 function print_usage() {
   printf '\n%b\n\n' "Usage: ${0} [ -l FILE ]"
-  printf '%b\n' "Create and populate a Gradle RO dependency cache volume to speed up builds of Single Cell Expression Atlas."
+  printf '%b\n' "Create and populate a Gradle wrapper and RO dependency cache volume to speed up builds of"
+  printf '%b\n' "Single Cell Expression Atlas."
   printf '\n%b\n\n' "-h\tShow usage instructions"
 }
 
@@ -34,28 +36,32 @@ do
   esac
 done
 
-print_stage_name "🗑 Remove previous version of ${GRADLE_RO_DEP_CACHE_VOL_NAME} if it exists"
-docker volume rm ${GRADLE_RO_DEP_CACHE_VOL_NAME} >> ${LOG_FILE} 2>&1 || true
+print_stage_name "🗑 Remove previous version of ${GRADLE_WRAPPER_DISTS_VOL_NAME} and ${GRADLE_RO_DEP_CACHE_VOL_NAME} if they exist"
+docker volume rm ${GRADLE_WRAPPER_DISTS_VOL_NAME} ${GRADLE_RO_DEP_CACHE_VOL_NAME} >> ${LOG_FILE} 2>&1 || true
 print_done
 
-print_stage_name "💾 Create Docker volume ${GRADLE_RO_DEP_CACHE_VOL_NAME}"
+print_stage_name "💾 Create Docker volumes ${GRADLE_WRAPPER_DISTS_VOL_NAME} ${GRADLE_RO_DEP_CACHE_VOL_NAME}"
+docker volume create ${GRADLE_WRAPPER_DISTS_VOL_NAME} >> ${LOG_FILE} 2>&1
 docker volume create ${GRADLE_RO_DEP_CACHE_VOL_NAME} >> ${LOG_FILE} 2>&1
 print_done
 
-IMAGE_NAME=scxa-gradle-ro-dep-cache-builder
+IMAGE_NAME=scxa-gradle-cache-builder
 print_stage_name "🚧 Build Docker image ${IMAGE_NAME}"
 docker build \
 -t ${IMAGE_NAME} ${SCRIPT_DIR} >> ${LOG_FILE} 2>&1
 print_done
 
+GRADLE_WRAPPER_DISTS_MAPPING=${GRADLE_WRAPPER_DISTS_VOL_NAME}:/gradle-wrapper-dists:rw
 GRADLE_RO_DEP_CACHE_MAPPING=${GRADLE_RO_DEP_CACHE_VOL_NAME}:/gradle-ro-dep-cache:rw
 print_stage_name "⚙ Spin up ephemeral container to copy local artifacts to dependency cache volume"
 docker run --rm \
+-v ${GRADLE_WRAPPER_DISTS_MAPPING} \
 -v ${GRADLE_RO_DEP_CACHE_MAPPING} \
 ${IMAGE_NAME} >> ${LOG_FILE} 2>&1
 print_done
 
 printf '%b\n' "🙂 All done! You can inspect the volume contents mounting it in a container:"
 printf '%b\n' "   docker run --rm \\"
+printf '%b\n' "   -v ${GRADLE_WRAPPER_DISTS_MAPPING} \\"
 printf '%b\n' "   -v ${GRADLE_RO_DEP_CACHE_MAPPING} \\"
 printf '%b\n' "   -it ubuntu:jammy bash"

--- a/docker/prepare-dev-environment/solr/docker-entrypoint.sh
+++ b/docker/prepare-dev-environment/solr/docker-entrypoint.sh
@@ -49,5 +49,3 @@ do
   MATRIX_MARKT_ROWS_GENES_FILE=/atlas-data/scxa/magetab/${EXP_ID}/${EXP_ID}.aggregated_filtered_normalised_counts.mtx_rows \
   ./load-scxa-gene2experiment.sh
 done
-
-sleep 3h


### PR DESCRIPTION
Besides a rogue `sleep` statement that had made its way to the Solr loader container, I’ve added a new volume to keep the Gradle wrapper packages so we don’t have to download them every time we run tests. Just remember to re-run the `./docker/prepare-dev-environment/gradle-ro-dep-cache/run.sh` to get the latest goodies.