### PR TITLE
Chore – Remove experiment design

### DIFF
--- a/app/src/main/java/uk/ac/ebi/atlas/experimentpage/tabs/ExperimentPageContentSerializer.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/experimentpage/tabs/ExperimentPageContentSerializer.java
@@ -35,10 +35,10 @@ public class ExperimentPageContentSerializer {
         var results = experimentPageContentService.getTsnePlotData(experiment.getAccession());
         availableTabs.add(customContentTab("results", "Results", results));
 
-        var experimentDesignJson =
-                experimentPageContentService.getExperimentDesign(
-                        experiment.getAccession(), new ExperimentDesignTable(experiment).asJson(), accessKey);
-        availableTabs.add(customContentTab("experiment-design", "Experiment Design", experimentDesignJson));
+//        var experimentDesignJson =
+//                experimentPageContentService.getExperimentDesign(
+//                        experiment.getAccession(), new ExperimentDesignTable(experiment).asJson(), accessKey);
+//        availableTabs.add(customContentTab("experiment-design", "Experiment Design", experimentDesignJson));
 
         var sections = new JsonObject();
         sections.add("sections", experimentPageContentService.getSupplementaryInformation(experiment.getAccession()));

--- a/app/src/main/java/uk/ac/ebi/atlas/experimentpage/tabs/ExperimentPageContentSerializer.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/experimentpage/tabs/ExperimentPageContentSerializer.java
@@ -4,7 +4,6 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Component;
-import uk.ac.ebi.atlas.model.experiment.ExperimentDesignTable;
 import uk.ac.ebi.atlas.trader.ExperimentTrader;
 
 import static uk.ac.ebi.atlas.utils.GsonProvider.GSON;
@@ -34,11 +33,6 @@ public class ExperimentPageContentSerializer {
 
         var results = experimentPageContentService.getTsnePlotData(experiment.getAccession());
         availableTabs.add(customContentTab("results", "Results", results));
-
-//        var experimentDesignJson =
-//                experimentPageContentService.getExperimentDesign(
-//                        experiment.getAccession(), new ExperimentDesignTable(experiment).asJson(), accessKey);
-//        availableTabs.add(customContentTab("experiment-design", "Experiment Design", experimentDesignJson));
 
         var sections = new JsonObject();
         sections.add("sections", experimentPageContentService.getSupplementaryInformation(experiment.getAccession()));

--- a/app/src/main/java/uk/ac/ebi/atlas/experimentpage/tabs/ExperimentPageContentService.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/experimentpage/tabs/ExperimentPageContentService.java
@@ -89,22 +89,6 @@ public class ExperimentPageContentService {
         return result;
     }
 
-    public JsonObject getExperimentDesign(String experimentAccession,
-                                          JsonObject experimentDesignTableAsJson,
-                                          String accessKey) {
-        var result = new JsonObject();
-
-        result.add("table", experimentDesignTableAsJson);
-
-        var fileUri =
-                experimentFileLocationService.getFileUri(
-                        experimentAccession, ExperimentFileType.EXPERIMENT_DESIGN, accessKey).toString();
-
-        result.addProperty("downloadUrl", fileUri);
-
-        return result;
-    }
-
     public JsonArray getDownloads(String experimentAccession, String accessKey) {
         var result = new JsonArray();
         var experiment = experimentTrader.getExperiment(experimentAccession, accessKey);

--- a/app/src/test/java/uk/ac/ebi/atlas/experimentpage/tabs/ExperimentPageContentServiceIT.java
+++ b/app/src/test/java/uk/ac/ebi/atlas/experimentpage/tabs/ExperimentPageContentServiceIT.java
@@ -98,15 +98,6 @@ class ExperimentPageContentServiceIT {
     }
 
     @Test
-    void getValidExperimentDesignJson() {
-        // TODO replace empty experiment design table with mock table
-        var experimentAccession = jdbcTestUtils.fetchRandomExperimentAccession();
-        var result = this.subject.getExperimentDesign(experimentAccession, new JsonObject(), "");
-        assertThat(result.has("table")).isTrue();
-        assertThat(result.has("downloadUrl")).isTrue();
-    }
-
-    @Test
     void getValidAnalysisMethodsJson() {
         var experimentAccession = jdbcTestUtils.fetchRandomExperimentAccession();
         var result = this.subject.getAnalysisMethods(experimentAccession);

--- a/app/src/test/java/uk/ac/ebi/atlas/home/LatestExperimentsServiceTest.java
+++ b/app/src/test/java/uk/ac/ebi/atlas/home/LatestExperimentsServiceTest.java
@@ -87,7 +87,7 @@ class LatestExperimentsServiceTest {
         jsonObject.add("technologyType", GSON.toJsonTree(experiment.getTechnologyType()));
         jsonObject.add(
                 "experimentalFactors",
-                GSON.toJsonTree(experiment.getExperimentDesign().getFactorHeaders()));
+                GSON.toJsonTree(experiment.getExperimentalFactorHeaders()));
         jsonObject.add(
                 "experimentProjects",
                 GSON.toJsonTree(List.of()));

--- a/jenkins-k8s-pod.yaml
+++ b/jenkins-k8s-pod.yaml
@@ -15,8 +15,7 @@ spec:
     - name: "kubectl"
       image: bitnami/kubectl
       command: [ "/bin/sh" ]
-      #args: [ "-c", "kubectl scale --replicas=2 solrcloud scxa && sleep 2h" ]
-      args: [ "-c", "sleep 2h" ]
+      args: [ "-c", "kubectl scale --replicas=2 solrcloud scxa && sleep 2h" ]
       resources:
         requests:
           memory: "0.5Gi"


### PR DESCRIPTION
The Experiment Design tab in the controller has been removed. Other than that, the big changes in this PR are in `atlas-web-core`.

Accompanied by https://github.com/ebi-gene-expression-group/atlas-web-core/pull/121.