### PR TITLE
Calculate HCA experiments number from db instead of hardcode

### DIFF
--- a/app/src/main/java/uk/ac/ebi/atlas/hcalandingpage/HcaLandingPageController.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/hcalandingpage/HcaLandingPageController.java
@@ -1,4 +1,6 @@
 package uk.ac.ebi.atlas.hcalandingpage;
+
+import org.springframework.http.MediaType;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -15,7 +17,7 @@ public class HcaLandingPageController extends HtmlExceptionHandlingController {
         this.experimentSearchService = experimentSearchService;
     }
 
-    @GetMapping(value = "/alpha/hca", produces = "text/html;charset=UTF-8")
+    @GetMapping(value = "json/alpha/hca", produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
     public String getHCAlandingpage(Model model) {
         model.addAttribute(
                 "hcaExperimentsCount",

--- a/app/src/main/java/uk/ac/ebi/atlas/hcalandingpage/HcaLandingPageController.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/hcalandingpage/HcaLandingPageController.java
@@ -1,15 +1,17 @@
 package uk.ac.ebi.atlas.hcalandingpage;
 
 import org.springframework.http.MediaType;
-import org.springframework.stereotype.Controller;
-import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
 import uk.ac.ebi.atlas.controllers.HtmlExceptionHandlingController;
 import uk.ac.ebi.atlas.experiments.ExperimentSearchService;
 
-import static uk.ac.ebi.atlas.hcalandingpage.JsonHcaLandingPageController.HCA_ACCESSION_PATTERN;
+import java.util.HashMap;
 
-@Controller
+import static uk.ac.ebi.atlas.hcalandingpage.JsonHcaLandingPageController.HCA_ACCESSION_PATTERN;
+import static uk.ac.ebi.atlas.utils.GsonProvider.GSON;
+
+@RestController
 public class HcaLandingPageController extends HtmlExceptionHandlingController {
     private ExperimentSearchService experimentSearchService;
 
@@ -17,16 +19,12 @@ public class HcaLandingPageController extends HtmlExceptionHandlingController {
         this.experimentSearchService = experimentSearchService;
     }
 
-    @GetMapping(value = "json/alpha/hca", produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
-    public String getHCAlandingpage(Model model) {
-        model.addAttribute(
-                "hcaExperimentsCount",
-                experimentSearchService.searchPublicExperimentsByAccession(HCA_ACCESSION_PATTERN).size());
-        model.addAttribute(
-                "humanExperimentsCount",
-                experimentSearchService.searchPublicExperimentsBySpecies("Homo sapiens").size());
-
-        return "hca-landing-page";
+    @GetMapping(value = "json/hca/experiments/count", produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+    public String getHCAAndHomoSapiensExperiments() {
+        HashMap<String, Integer> HCAAndHomoSapiensExperimentsCount = new HashMap<>();
+        HCAAndHomoSapiensExperimentsCount.put("hcaExperimentsCount", experimentSearchService.searchPublicExperimentsByAccession(HCA_ACCESSION_PATTERN).size());
+        HCAAndHomoSapiensExperimentsCount.put("humanExperimentsCount", experimentSearchService.searchPublicExperimentsBySpecies("Homo sapiens").size());
+        return GSON.toJson(HCAAndHomoSapiensExperimentsCount);
     }
 }
 

--- a/app/src/test/java/uk/ac/ebi/atlas/hcalandingpage/HcaLandingPageControllerWIT.java
+++ b/app/src/test/java/uk/ac/ebi/atlas/hcalandingpage/HcaLandingPageControllerWIT.java
@@ -6,9 +6,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.ClassPathResource;
+import org.springframework.http.MediaType;
 import org.springframework.jdbc.datasource.init.ResourceDatabasePopulator;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
@@ -18,23 +18,22 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 import uk.ac.ebi.atlas.configuration.TestConfig;
 
-
 import javax.inject.Inject;
 import javax.sql.DataSource;
 
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
 
 @ExtendWith(SpringExtension.class)
 @WebAppConfiguration
 @ContextConfiguration(classes = TestConfig.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class HcaLandingPageControllerWIT {
-    private static final String URL = "/alpha/hca";
+    private static final String URL = "json/hca/experiments/count";
 
     @Inject
     private DataSource dataSource;
@@ -68,8 +67,8 @@ public class HcaLandingPageControllerWIT {
     void validExperimentAccession() throws Exception {
         mockMvc.perform(get(URL))
                 .andExpect(status().isOk())
-                .andExpect(view().name("hca-landing-page"))
-                .andExpect(model().attribute("hcaExperimentsCount", is(greaterThan(0))))
-                .andExpect(model().attribute("humanExperimentsCount", is(greaterThan(0))));
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8))
+                .andExpect(jsonPath("$..humanExperimentsCount", is(greaterThan(0))))
+                .andExpect(jsonPath("$..hcaExperimentsCount", is(greaterThan(0))));
     }
 }

--- a/app/src/test/java/uk/ac/ebi/atlas/hcalandingpage/HcaLandingPageControllerWIT.java
+++ b/app/src/test/java/uk/ac/ebi/atlas/hcalandingpage/HcaLandingPageControllerWIT.java
@@ -33,7 +33,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @ContextConfiguration(classes = TestConfig.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class HcaLandingPageControllerWIT {
-    private static final String URL = "json/hca/experiments/count";
+    private static final String URL = "/json/hca/experiments/count";
 
     @Inject
     private DataSource dataSource;
@@ -64,11 +64,11 @@ public class HcaLandingPageControllerWIT {
     }
 
     @Test
-    void validExperimentAccession() throws Exception {
+    void homoSapiensAndHCAExperimentsCountShouldBeNonZero() throws Exception {
         mockMvc.perform(get(URL))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8))
-                .andExpect(jsonPath("$..humanExperimentsCount", is(greaterThan(0))))
-                .andExpect(jsonPath("$..hcaExperimentsCount", is(greaterThan(0))));
+                .andExpect(jsonPath("$.humanExperimentsCount", is(greaterThan(0))))
+                .andExpect(jsonPath("$.hcaExperimentsCount", is(greaterThan(0))));
     }
 }


### PR DESCRIPTION
This PR contains only backend changes.

Here is the front-end PR reference - [front-end-pr](https://gitlab.ebi.ac.uk/ebi-gene-expression/expression-atlas-web/hca-landing-page/-/merge_requests/7)

Simple and straightforward for the review :).

Endpoint -` http://localhost:8080/gxa/sc/json/hca/experiments/count`

Response:  `{"humanExperimentsCount":2,"hcaExperimentsCount":1}`