### PR TITLE
Enable SolrCloud cluster scaler pod

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -92,8 +92,8 @@ pipeline {
                     '-PjdbcUrl=jdbc:postgresql://localhost:5432/postgres?currentSchema=scxa ' +
                     '-PjdbcUsername=postgres ' +
                     '-PjdbcPassword=postgres ' +
-                    '-PzkHosts=scxa-zk-fast-0.scxa-zk-hs.jenkins-gene-expression.svc.cluster.local:2181,scxa-zk-fast-1.scxa-zk-hs.jenkins-gene-expression.svc.cluster.local:2181,scxa-zk-fast-2.scxa-zk-hs.jenkins-gene-expression.svc.cluster.local:2181 ' +
-                    '-PsolrHosts=http://scxa-solrcloud-fast-0.scxa-solrcloud-fast-hs.jenkins-gene-expression.svc.cluster.local:8983/solr,http://scxa-solrcloud-fast-1.scxa-solrcloud-fast-hs.jenkins-gene-expression.svc.cluster.local:8983/solr ' +
+                    '-PzkHosts=scxa-solrcloud-zookeeper-0.scxa-solrcloud-zookeeper-headless.jenkins-gene-expression.svc.cluster.local:2181,scxa-solrcloud-zookeeper-1.scxa-solrcloud-zookeeper-headless.jenkins-gene-expression.svc.cluster.local:2181,scxa-solrcloud-zookeeper-2.scxa-solrcloud-zookeeper-headless.jenkins-gene-expression.svc.cluster.local:2181 ' +
+                    '-PsolrHosts=http://scxa-solrcloud-0.scxa-solrcloud-headless.jenkins-gene-expression.svc.cluster.local:8983/solr,http://scxa-solrcloud-1.scxa-solrcloud-headless.jenkins-gene-expression.svc.cluster.local:8983/solr ' +
                     ':app:testClasses'
           }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -51,8 +51,8 @@ pipeline {
                     '-PjdbcUrl=jdbc:postgresql://localhost:5432/postgres?currentSchema=gxa ' +
                     '-PjdbcUsername=postgres ' +
                     '-PjdbcPassword=postgres ' +
-                    '-PzkHosts=scxa-solrcloud-zookeeper-0.scxa-solrcloud-zookeeper-headless.jenkins-gene-expression.svc.cluster.local:2181,scxa-solrcloud-zookeeper-1.scxa-solrcloud-zookeeper-headless.jenkins-gene-expression.svc.cluster.local:2181,scxa-solrcloud-zookeeper-2.scxa-solrcloud-zookeeper-headless.jenkins-gene-expression.svc.cluster.local:2181 ' +
-                    '-PsolrHosts=http://scxa-solrcloud-0.scxa-solrcloud-headless.jenkins-gene-expression.svc.cluster.local:8983/solr,http://scxa-solrcloud-1.scxa-solrcloud-headless.jenkins-gene-expression.svc.cluster.local:8983/solr ' +
+                    '-PzkHosts=scxa-zk-fast-0.scxa-zk-hs.jenkins-gene-expression.svc.cluster.local:2181,scxa-zk-fast-1.scxa-zk-hs.jenkins-gene-expression.svc.cluster.local:2181,scxa-zk-fast-2.scxa-zk-hs.jenkins-gene-expression.svc.cluster.local:2181 ' +
+                    '-PsolrHosts=http://scxa-solrcloud-fast-0.scxa-solrcloud-fast-hs.jenkins-gene-expression.svc.cluster.local:8983/solr,http://scxa-solrcloud-fast-1.scxa-solrcloud-fast-hs.jenkins-gene-expression.svc.cluster.local:8983/solr ' +
                     ':atlas-web-core:testClasses'
           }
         }
@@ -92,8 +92,8 @@ pipeline {
                     '-PjdbcUrl=jdbc:postgresql://localhost:5432/postgres?currentSchema=scxa ' +
                     '-PjdbcUsername=postgres ' +
                     '-PjdbcPassword=postgres ' +
-                    '-PzkHosts=scxa-solrcloud-zookeeper-0.scxa-solrcloud-zookeeper-headless.jenkins-gene-expression.svc.cluster.local:2181,scxa-solrcloud-zookeeper-1.scxa-solrcloud-zookeeper-headless.jenkins-gene-expression.svc.cluster.local:2181,scxa-solrcloud-zookeeper-2.scxa-solrcloud-zookeeper-headless.jenkins-gene-expression.svc.cluster.local:2181 ' +
-                    '-PsolrHosts=http://scxa-solrcloud-0.scxa-solrcloud-headless.jenkins-gene-expression.svc.cluster.local:8983/solr,http://scxa-solrcloud-1.scxa-solrcloud-headless.jenkins-gene-expression.svc.cluster.local:8983/solr ' +
+                    '-PzkHosts=scxa-zk-fast-0.scxa-zk-hs.jenkins-gene-expression.svc.cluster.local:2181,scxa-zk-fast-1.scxa-zk-hs.jenkins-gene-expression.svc.cluster.local:2181,scxa-zk-fast-2.scxa-zk-hs.jenkins-gene-expression.svc.cluster.local:2181 ' +
+                    '-PsolrHosts=http://scxa-solrcloud-fast-0.scxa-solrcloud-fast-hs.jenkins-gene-expression.svc.cluster.local:8983/solr,http://scxa-solrcloud-fast-1.scxa-solrcloud-fast-hs.jenkins-gene-expression.svc.cluster.local:8983/solr ' +
                     ':app:testClasses'
           }
         }

--- a/jenkins-k8s-pod.yaml
+++ b/jenkins-k8s-pod.yaml
@@ -15,8 +15,7 @@ spec:
     - name: "kubectl"
       image: bitnami/kubectl
       command: [ "/bin/sh" ]
-      #args: [ "-c", "kubectl scale --replicas=2 solrcloud scxa && sleep 2h" ]
-      args: [ "-c", "sleep 2h" ]
+      args: [ "-c", "kubectl scale --replicas=2 solrcloud scxa && sleep 2h" ]
       resources:
         requests:
           memory: "0.5Gi"


### PR DESCRIPTION
After the Cloud Team fixed the permissions in the `admin-jenkins-gene-expression` service account (set at the top of the YAML file) the pod that scales up SolrCloud is now working. This can bring costs down significantly, because the SolrCloud cluster will be scaled to 0 replicas and it will only be scaled up before a Jenkins agent starts working. A cron job checks every hour if Jenkins agents are running, based on a regex pod name match, and if none are found, then the SolrCloud stateful set is scaled down. See https://github.com/ebi-gene-expression-group/atlas-k8s-ci-environment/pull/2/files.

I also tested to run the tests with a SolrCloud cluster with “premium” (i.e. fast SSD) storage, but it hardly makes any difference, if at all. However, SSD storage was set for ZooKeeper from the start because it’s encouraged in ZK documentation. We also heard from bad experiences in PRIDE when they used NFS with ZooKeeper, and it couldn’t keep up.