### PR TITLE
Fix the parameter check for cell plot

### DIFF
--- a/app/src/main/java/uk/ac/ebi/atlas/experimentpage/cellplot/JsonCellPlotController.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/experimentpage/cellplot/JsonCellPlotController.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import uk.ac.ebi.atlas.controllers.JsonExceptionHandlingController;
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.Map;
 import java.util.Optional;
@@ -38,7 +39,7 @@ JsonCellPlotController extends JsonExceptionHandlingController {
 
         // Check that no param is missing
         var requiredParametersBuilder = ImmutableMap.<String, Integer>builder();
-        for (var requiredParameter : requiredParameters) {
+        var requiredParameter = StringUtils.substringsBetween(requiredParameters.get(0) , "\"", "\"")[0];
             if (!requestParams.containsKey(requiredParameter)) {
                 throw new IllegalArgumentException("Missing parameter " + requiredParameter);
             } else {
@@ -51,7 +52,6 @@ JsonCellPlotController extends JsonExceptionHandlingController {
                                     requiredParameter + "=" + requestParams.get(requiredParameter));
                 }
             }
-        }
 
         return requiredParametersBuilder.build();
     }


### PR DESCRIPTION
I fix the logic to check cell plot paramters.
For example: 
1. `http://localhost:8080/gxa/sc/json/cell-plots/E-EHCA-2/clusters/metadata/inferred%20cell%20type%20-%20authors%20labels?plotMethod=tsne&accessKey=&perplexit=25` should response 
```
{
    "error": "Missing parameter perplexity"
}
```
2. `http://localhost:8080/gxa/sc/json/cell-plots/E-EHCA-2/clusters/metadata/inferred%20cell%20type%20-%20authors%20labels?plotMethod=umap&accessKey=&perplexit=25` should response 
```
{
     "error": "Missing parameter n_neighbors"
}
```
3.  `http://localhost:8080/gxa/sc/json/cell-plots/E-EHCA-2/clusters/metadata/inferred%20cell%20type%20-%20authors%20labels?plotMethod=tsne&accessKey=&perplexity=25` should response properly. 