### PR TITLE
Feature/validate parameterisation for cell type endpoints

### DIFF
--- a/app/src/main/java/uk/ac/ebi/atlas/experimentpage/cellplot/JsonCellPlotController.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/experimentpage/cellplot/JsonCellPlotController.java
@@ -11,9 +11,10 @@ import org.springframework.web.bind.annotation.RestController;
 import uk.ac.ebi.atlas.controllers.JsonExceptionHandlingController;
 import org.apache.commons.lang3.StringUtils;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-
+import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping(value="/json/cell-plots/{experimentAccession}", method= RequestMethod.GET)
@@ -40,19 +41,20 @@ JsonCellPlotController extends JsonExceptionHandlingController {
         // Check that no param is missing
         var requiredParametersBuilder = ImmutableMap.<String, Integer>builder();
         var requiredParameter = StringUtils.substringsBetween(requiredParameters.get(0) , "\"", "\"")[0];
-            if (!requestParams.containsKey(requiredParameter)) {
-                throw new IllegalArgumentException("Missing parameter " + requiredParameter);
-            } else {
-                try {
-                    requiredParametersBuilder.put(
-                            requiredParameter, Integer.parseInt(requestParams.get(requiredParameter)));
-                } catch (NumberFormatException e) {
-                    throw new IllegalArgumentException(
-                            "Invalid plot parameter value " +
-                                    requiredParameter + "=" + requestParams.get(requiredParameter));
-                }
-            }
-
+        List<String> parameterisations = requiredParameters.stream().map(parameter ->
+                StringUtils.substringsBetween(parameter, ":","}")[0]).collect(Collectors.toList());
+        if (!requestParams.containsKey(requiredParameter)) {
+            throw new IllegalArgumentException("Missing parameter " + requiredParameter);
+        }
+        else if (!parameterisations.contains(requestParams.get(requiredParameter))) {
+            throw new IllegalArgumentException(
+                    "Invalid plot parameter value " +
+                            requiredParameter + "=" + requestParams.get(requiredParameter));
+        }
+        else {
+            requiredParametersBuilder.put(
+                    requiredParameter, Integer.parseInt(requestParams.get(requiredParameter)));
+        }
         return requiredParametersBuilder.build();
     }
 

--- a/app/src/main/java/uk/ac/ebi/atlas/experimentpage/cellplot/JsonCellPlotController.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/experimentpage/cellplot/JsonCellPlotController.java
@@ -41,8 +41,8 @@ JsonCellPlotController extends JsonExceptionHandlingController {
         // Check that no param is missing
         var requiredParametersBuilder = ImmutableMap.<String, Integer>builder();
         var requiredParameter = StringUtils.substringsBetween(requiredParameters.get(0) , "\"", "\"")[0];
-        List<String> parameterisations = requiredParameters.stream().map(parameter ->
-                StringUtils.substringsBetween(parameter, ":","}")[0]).collect(Collectors.toList());
+        var parameterisations = requiredParameters.stream().map(parameter ->
+                StringUtils.substringsBetween(parameter, " ","}")[0]).collect(Collectors.toList());
         if (!requestParams.containsKey(requiredParameter)) {
             throw new IllegalArgumentException("Missing parameter " + requiredParameter);
         }


### PR DESCRIPTION
In this feature, we check if the user-input parameterisation value is existed in the database.

For example: `http://localhost:8080/gxa/sc/json/cell-plots/E-EHCA-2/clusters/metadata/inferred%20cell%20type%20-%20authors%20labels?plotMethod=tsne&accessKey=&perplexity=12` should return 
```
error | "Invalid plot parameter value perplexity=12"
```