### PR TITLE
Chore – Gene search optimization

### DIFF
--- a/app/src/main/java/uk/ac/ebi/atlas/search/JsonGeneSearchController.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/search/JsonGeneSearchController.java
@@ -83,10 +83,10 @@ public class JsonGeneSearchController extends JsonExceptionHandlingController {
         var resultsBuilder = ImmutableList.builder();
         // This was a very expressive stream chain (look it up in the history), but to filter by results where the gene
         // is a marker, making it a for loop is more readable IMHO; I also noticed a 10% performance improvement
-        for (var i = 0; i < expressedGeneIdEntries.size(); i++) {
-            var geneId = expressedGeneIdEntries.get(i).getKey();
+        for (var expressedGeneIdEntry : expressedGeneIdEntries) {
+            var geneId = expressedGeneIdEntry.getKey();
 
-            var exp2cellsIt = expressedGeneIdEntries.get(i).getValue().entrySet().iterator();
+            var exp2cellsIt = expressedGeneIdEntry.getValue().entrySet().iterator();
             while (exp2cellsIt.hasNext()) {
                 var exp2cells = exp2cellsIt.next();
                 var experimentAccession = exp2cells.getKey();

--- a/app/src/main/java/uk/ac/ebi/atlas/search/JsonGeneSearchController.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/search/JsonGeneSearchController.java
@@ -86,9 +86,7 @@ public class JsonGeneSearchController extends JsonExceptionHandlingController {
         for (var expressedGeneIdEntry : expressedGeneIdEntries) {
             var geneId = expressedGeneIdEntry.getKey();
 
-            var exp2cellsIt = expressedGeneIdEntry.getValue().entrySet().iterator();
-            while (exp2cellsIt.hasNext()) {
-                var exp2cells = exp2cellsIt.next();
+            for (var exp2cells : expressedGeneIdEntry.getValue().entrySet()) {
                 var experimentAccession = exp2cells.getKey();
 
                 stopWatch.start("Get facets iteration for " + geneId + " in " + experimentAccession);

--- a/app/src/main/java/uk/ac/ebi/atlas/search/JsonGeneSearchController.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/search/JsonGeneSearchController.java
@@ -5,8 +5,11 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.MediaType;
 import org.springframework.util.MultiValueMap;
+import org.springframework.util.StopWatch;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -26,9 +29,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static uk.ac.ebi.atlas.search.FacetGroupName.MARKER_GENE;
 import static uk.ac.ebi.atlas.search.FacetGroupName.ORGANISM;
 import static uk.ac.ebi.atlas.utils.GsonProvider.GSON;
@@ -36,6 +39,8 @@ import static uk.ac.ebi.atlas.utils.GsonProvider.GSON;
 @RestController
 @RequiredArgsConstructor
 public class JsonGeneSearchController extends JsonExceptionHandlingController {
+    private static final Logger LOGGER = LoggerFactory.getLogger(JsonGeneSearchController.class);
+
     private final GeneIdSearchService geneIdSearchService;
     private final GeneSearchService geneSearchService;
     private final ExperimentTrader experimentTrader;
@@ -46,9 +51,14 @@ public class JsonGeneSearchController extends JsonExceptionHandlingController {
 
     @GetMapping(value = "/json/search", produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
     public String search(@RequestParam MultiValueMap<String, String> requestParams) {
+        var stopWatch = new StopWatch();
+        stopWatch.start("geneQuery = geneIdSearchService.getGeneQueryByRequestParams(requestParams)");
         var geneQuery = geneIdSearchService.getGeneQueryByRequestParams(requestParams);
+        stopWatch.stop();
 
+        stopWatch.start("geneIds = geneIdSearchService.search(geneQuery)");
         var geneIds = geneIdSearchService.search(geneQuery);
+        stopWatch.stop();
 
         var emptyGeneIdError = geneIdEmptyValidation(geneIds);
         if (emptyGeneIdError.isPresent()) {
@@ -56,68 +66,89 @@ public class JsonGeneSearchController extends JsonExceptionHandlingController {
         }
 
         // We found expressed gene IDs, let’s get to it now...
+        stopWatch.start("expressedGeneIdEntries = getMarkerGeneProfileByGeneIds(geneIds)");
         var expressedGeneIdEntries = getMarkerGeneProfileByGeneIds(geneIds);
+        stopWatch.stop();
 
+        stopWatch.start("markerGeneFacets = geneSearchService.getMarkerGeneProfile(...)");
         var markerGeneFacets =
                 geneSearchService.getMarkerGeneProfile(
                         expressedGeneIdEntries.stream()
                                 .map(Map.Entry::getKey)
-                                .toArray(String[]::new));
+                                .collect(toImmutableSet()));
+        stopWatch.stop();
 
-        // geneSearchServiceDao guarantees that values in the inner maps can’t be empty. The map itself may be empty
+        // geneSearchServiceDao guarantees that values in the inner maps can’t be empty; the map itself may be empty
         // but if there’s an entry the list will have at least on element
-        var results =
-                expressedGeneIdEntries.stream()
-                        // TODO Measure in production if parallelising the stream results in any speedup
-                        //      (the more experiments we have the better). BEWARE: just adding parallel() throws! (?)
-                        .flatMap(entry -> entry.getValue().entrySet().stream().map(exp2cells -> {
+        var resultsBuilder = ImmutableList.builder();
+        // This was a very expressive stream chain (look it up in the history), but to filter by results where the gene
+        // is a marker, making it a for loop is more readable IMHO; I also noticed a 10% performance improvement
+        for (var i = 0; i < expressedGeneIdEntries.size(); i++) {
+            var geneId = expressedGeneIdEntries.get(i).getKey();
 
-                            // Inside this map-within-a-flatMap we unfold expressedGeneIdEntries to triplets of...
-                            var geneId = entry.getKey();
-                            var experimentAccession = exp2cells.getKey();
-                            var cellIds = exp2cells.getValue();
+            var exp2cellsIt = expressedGeneIdEntries.get(i).getValue().entrySet().iterator();
+            while (exp2cellsIt.hasNext()) {
+                var exp2cells = exp2cellsIt.next();
+                var experimentAccession = exp2cells.getKey();
 
-                            var experimentAttributes =
-                                    ImmutableMap.<String, Object>builder().putAll(
-                                            getExperimentInformation(experimentAccession, geneId));
-                            var facets =
-                                    ImmutableList.<Map<String, String>>builder().addAll(
-                                            unfoldFacets(geneSearchService.getFacets(cellIds)
-                                                    .getOrDefault(experimentAccession, ImmutableMap.of())));
+                stopWatch.start("Get facets iteration for " + geneId + " in " + experimentAccession);
+                if (markerGeneFacets.containsKey(geneId) &&
+                        markerGeneFacets.get(geneId).containsKey(experimentAccession)) {
+                    var cellIds = exp2cells.getValue();
 
-                            if (markerGeneFacets.containsKey(geneId) &&
-                                    markerGeneFacets.get(geneId).containsKey(experimentAccession)) {
-                                facets.add(
-                                        ImmutableMap.of(
-                                                "group", MARKER_GENE.getTitle(),
-                                                "value", "experiments with marker genes",
-                                                "label", "Experiments with marker genes",
-                                                "description", MARKER_GENE.getTooltip()));
-                                experimentAttributes.put(
-                                        "markerGenes",
-                                        convertMarkerGeneModel(
-                                                experimentAccession,
-                                                geneId,
-                                                markerGeneFacets.get(geneId).get(experimentAccession)));
-                            } else {
-                                experimentAttributes.put(
-                                        "markerGenes", ImmutableList.of());
-                            }
+                    var experimentAttributes =
+                            ImmutableMap.<String, Object>builder().putAll(
+                                    getExperimentInformation(experimentAccession, geneId));
 
-                            return ImmutableMap.of("element", experimentAttributes.build(), "facets", facets.build());
+                    var facets =
+                            ImmutableList.<Map<String, String>>builder()
+                                    .addAll(
+                                            unfoldFacets(
+                                                    geneSearchService.getFacets(cellIds)
+                                                            .getOrDefault(experimentAccession, ImmutableMap.of())));
 
-                        })).collect(toImmutableList());
+                    facets.add(
+                            ImmutableMap.of(
+                                    "group", MARKER_GENE.getTitle(),
+                                    "value", "experiments with marker genes",
+                                    "label", "Experiments with marker genes",
+                                    "description", MARKER_GENE.getTooltip()));
+                    experimentAttributes.put(
+                            "markerGenes",
+                            convertMarkerGeneModel(
+                                    experimentAccession,
+                                    geneId,
+                                    markerGeneFacets.get(geneId).get(experimentAccession)));
 
-        var matchingGeneIds = "";
-        if (geneIds.get().size() == 1 && !geneIds.get().iterator().next().equals(geneQuery.queryTerm())) {
-            matchingGeneIds = "(" + String.join(", ", geneIds.get()) + ")";
+                    resultsBuilder.add(ImmutableMap.of("element", experimentAttributes.build(), "facets", facets.build()));
+                }
+                stopWatch.stop();
+            }
         }
 
-        return GSON.toJson(
+        stopWatch.start("Build results and serialize to JSON");
+        var results = resultsBuilder.build();
+
+        // If the query term matches a single Ensembl ID different to the query term, we return it in the response.
+        // The most common case is a non-Ensembl gene identifier (e.g. Entrez, MGI, ...).
+        var matchingGeneIds =
+                (geneIds.get().size() == 1 && !geneIds.get().iterator().next().equals(geneQuery.queryTerm())) ?
+                        "(" + String.join(", ", geneIds.get()) + ")" :
+                        "";
+
+        var json = GSON.toJson(
                 ImmutableMap.of(
                         "matchingGeneId", matchingGeneIds,
                         "results", results,
                         "checkboxFacetGroups", ImmutableList.of(MARKER_GENE.getTitle(), ORGANISM.getTitle())));
+        stopWatch.stop();
+
+        LOGGER.debug("Search results for {} in {} ms: {}",
+                geneQuery.queryTerm(),
+                stopWatch.getTotalTimeMillis(),
+                stopWatch.prettyPrint());
+
+        return json;
     }
 
     @GetMapping(value = "/json/gene-search/marker-genes", produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
@@ -137,7 +168,7 @@ public class JsonGeneSearchController extends JsonExceptionHandlingController {
                 geneSearchService.getMarkerGeneProfile(
                         expressedGeneIdEntries.stream()
                                 .map(Map.Entry::getKey)
-                                .toArray(String[]::new));
+                                .collect(toImmutableSet()));
 
         return markerGeneFacets != null && markerGeneFacets.size() > 0;
     }
@@ -182,8 +213,7 @@ public class JsonGeneSearchController extends JsonExceptionHandlingController {
     private ImmutableList<Map.Entry<String, Map<String, List<String>>>> getMarkerGeneProfileByGeneIds(Optional<ImmutableSet<String>> geneIds) {
         // We found expressed gene IDs, let’s get to it now...
         var geneIds2ExperimentAndCellIds =
-                geneSearchService.getCellIdsInExperiments(
-                        geneIds.get().toArray(new String[0]));
+                geneSearchService.getCellIdsInExperiments(geneIds.get());
 
         return geneIds2ExperimentAndCellIds.entrySet().stream()
                         .filter(entry -> !entry.getValue().isEmpty())

--- a/app/src/main/java/uk/ac/ebi/atlas/search/geneids/GeneIdSearchDao.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/search/geneids/GeneIdSearchDao.java
@@ -38,7 +38,7 @@ public class GeneIdSearchDao {
         this.experimentTraderDao = experimentTraderDao;
     }
 
-    // This is one of the edge cases where an empty optional is semantically different than an empty collection. The
+    // This is one of the few cases where an empty optional is semantically different from an empty collection. The
     // former signals that there were no matching gene IDs in the “Atlas knowledge base” (aka bioentities collection),
     // whereas the latter means that a known gene ID couldn’t be found in any SC experiment. Another alternative could
     // be to return a Pair<String, Set> where the left would contain a message if the right is empty or null (like
@@ -48,9 +48,7 @@ public class GeneIdSearchDao {
                 new SolrQueryBuilder<BioentitiesCollectionProxy>()
                         .addFilterFieldByTerm(SPECIES, species)
                         .addQueryFieldByTerm(PROPERTY_VALUE, propertyValue)
-                        .addQueryFieldByTerm(PROPERTY_NAME, propertyName)
-                        .setFieldList(BioentitiesCollectionProxy.BIOENTITY_IDENTIFIER)
-                        .sortBy(BioentitiesCollectionProxy.BIOENTITY_IDENTIFIER, SolrQuery.ORDER.asc);
+                        .addQueryFieldByTerm(PROPERTY_NAME, propertyName);
         return searchInTwoSteps(bioentitiesQueryBuilder);
     }
 
@@ -58,15 +56,17 @@ public class GeneIdSearchDao {
         var bioentitiesQueryBuilder =
                 new SolrQueryBuilder<BioentitiesCollectionProxy>()
                         .addQueryFieldByTerm(PROPERTY_VALUE, propertyValue)
-                        .addQueryFieldByTerm(PROPERTY_NAME, propertyName)
-                        .setFieldList(BioentitiesCollectionProxy.BIOENTITY_IDENTIFIER)
-                        .sortBy(BioentitiesCollectionProxy.BIOENTITY_IDENTIFIER, SolrQuery.ORDER.asc);
+                        .addQueryFieldByTerm(PROPERTY_NAME, propertyName);
         return searchInTwoSteps(bioentitiesQueryBuilder);
     }
 
     private Optional<ImmutableSet<String>> searchInTwoSteps(
             SolrQueryBuilder<BioentitiesCollectionProxy> bioentitiesQueryBuilder) {
-        bioentitiesQueryBuilder.setRows(1);
+        bioentitiesQueryBuilder
+                .setRows(1)
+                .setFieldList(BioentitiesCollectionProxy.BIOENTITY_IDENTIFIER_DV)
+                .sortBy(BioentitiesCollectionProxy.BIOENTITY_IDENTIFIER_DV, SolrQuery.ORDER.asc);
+
 
         var bioentitiesSearchBuilder =
                 new SearchStreamBuilder<>(bioentitiesCollectionProxy, bioentitiesQueryBuilder);

--- a/app/src/main/webapp/WEB-INF/jsp/tiles/views/home/search.jsp
+++ b/app/src/main/webapp/WEB-INF/jsp/tiles/views/home/search.jsp
@@ -19,6 +19,7 @@
         geneSearchForm.render({
             host: '${pageContext.request.contextPath}/',
             resource: 'json/suggestions/species',
+            defaultSpecies: `Homo sapiens`,
             wrapperClassName: 'row expanded',
             actionEndpoint: 'search',
 
@@ -35,8 +36,8 @@
                     url: '${pageContext.request.contextPath}/search?symbol=CFTR'
                 },
                 {
-                    text: 'ENSG00000115904 (Ensembl ID)',
-                    url: '${pageContext.request.contextPath}/search?ensgene=ENSG00000115904'
+                    text: 'ENSG00000125798 (Ensembl ID)',
+                    url: '${pageContext.request.contextPath}/search?ensgene=ENSG00000125798'
                 },
                 {
                     text: '657 (Entrez ID)',

--- a/app/src/test/java/uk/ac/ebi/atlas/search/GeneSearchServiceIT.java
+++ b/app/src/test/java/uk/ac/ebi/atlas/search/GeneSearchServiceIT.java
@@ -1,5 +1,6 @@
 package uk.ac.ebi.atlas.search;
 
+import com.google.common.collect.ImmutableSet;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
@@ -69,7 +70,7 @@ class GeneSearchServiceIT {
 	@ParameterizedTest
     void experimentsWithoutPreferredKReturnASingleProfile(String experimentAccession) {
         String geneId = jdbcTestUtils.fetchRandomMarkerGeneFromSingleCellExperiment(experimentAccession);
-        assertThat(subject.getMarkerGeneProfile(geneId)).hasSize(1);
+        assertThat(subject.getMarkerGeneProfile(ImmutableSet.of(geneId))).hasSize(1);
     }
 
     private Stream<String> experimentAccesionWithoutPreferredKProvider() {

--- a/app/src/test/java/uk/ac/ebi/atlas/search/GeneSearchServiceTest.java
+++ b/app/src/test/java/uk/ac/ebi/atlas/search/GeneSearchServiceTest.java
@@ -66,7 +66,7 @@ class GeneSearchServiceTest {
 
         when(geneSearchDaoMock.fetchCellIds(geneId)).thenReturn(ensg00000104957Cells);
 
-        Map<String, Map<String, List<String>>> result = subject.getCellIdsInExperiments(geneId);
+        Map<String, Map<String, List<String>>> result = subject.getCellIdsInExperiments(ImmutableSet.of(geneId));
 
         assertThat(result)
                 .containsOnlyKeys(geneId)
@@ -98,7 +98,7 @@ class GeneSearchServiceTest {
         when(geneSearchDaoMock.fetchCellIds(geneId1)).thenReturn(ensfoobar1Cells);
         when(geneSearchDaoMock.fetchCellIds(geneId2)).thenReturn(ensfoobar2Cells);
 
-        assertThat(subject.getCellIdsInExperiments(geneId1, geneId2))
+        assertThat(subject.getCellIdsInExperiments(ImmutableSet.of(geneId1, geneId2)))
                 .containsAllEntriesOf(ImmutableMap.of(geneId1, ensfoobar1Cells, geneId2, ensfoobar2Cells));
     }
 
@@ -126,7 +126,7 @@ class GeneSearchServiceTest {
                 .fetchExperimentAccessionsWhereGeneIsMarker(geneId))
                 .thenReturn(ImmutableList.of(experimentAccession1, experimentAccession2));
 
-        Map<String, Map<String, Map<Integer, List<Integer>>>> result = subject.getMarkerGeneProfile(geneId);
+        Map<String, Map<String, Map<Integer, List<Integer>>>> result = subject.getMarkerGeneProfile(ImmutableSet.of(geneId));
 
         assertThat(result)
                 .isNotEmpty()
@@ -183,7 +183,7 @@ class GeneSearchServiceTest {
         when(geneSearchDaoMock.fetchExperimentAccessionsWhereGeneIsMarker(geneId2))
                 .thenReturn(ImmutableList.of(experimentAccession3, experimentAccession4));
 
-        assertThat(subject.getMarkerGeneProfile(geneId1, geneId2))
+        assertThat(subject.getMarkerGeneProfile(ImmutableSet.of(geneId1, geneId2)))
                 .containsAllEntriesOf(
                         ImmutableMap.of(
                                 geneId1,
@@ -227,7 +227,7 @@ class GeneSearchServiceTest {
         doThrow(new UncheckedIOException(new IOException())).when(geneSearchDaoMock).fetchCellIds(anyString());
 
         assertThatExceptionOfType(RuntimeException.class).isThrownBy(
-                () -> subject.getCellIdsInExperiments(generateRandomExperimentAccession()))
+                () -> subject.getCellIdsInExperiments(ImmutableSet.of(generateRandomExperimentAccession())))
                 .withCauseInstanceOf(ExecutionException.class);
     }
 

--- a/app/src/test/java/uk/ac/ebi/atlas/search/JsonGeneSearchControllerIT.java
+++ b/app/src/test/java/uk/ac/ebi/atlas/search/JsonGeneSearchControllerIT.java
@@ -141,9 +141,9 @@ class JsonGeneSearchControllerIT {
                 .thenReturn(geneQuery);
         when(geneIdSearchServiceMock.search(geneQuery))
                 .thenReturn(Optional.of(ImmutableSet.of(geneId)));
-        when(geneSearchServiceMock.getCellIdsInExperiments(geneId))
+        when(geneSearchServiceMock.getCellIdsInExperiments(ImmutableSet.of(geneId)))
                 .thenReturn(Map.of(geneId, Map.of(experimentAccession, List.of(cellId))));
-        when(geneSearchServiceMock.getMarkerGeneProfile(geneId))
+        when(geneSearchServiceMock.getMarkerGeneProfile(ImmutableSet.of(geneId)))
                 .thenReturn(ImmutableMap.of(geneId, Map.of(experimentAccession, Map.of(kValue, clusterIds))));
 
         boolean isMarkerGene = subject.isMarkerGene(requestParams);

--- a/docker/docker-compose-tomcat.yml
+++ b/docker/docker-compose-tomcat.yml
@@ -8,6 +8,7 @@ services:
       - atlas-test-net
     environment:
       JPDA_ADDRESS: "*:8000"
+      JAVA_OPTS: "-Dsolr.httpclient.builder.factory=org.apache.solr.client.solrj.impl.PreemptiveBasicAuthClientBuilderFactory -Dbasicauth=solr:SolrRocks"
     ports:
       - "8080:8080"
       - "8000:8000"

--- a/docker/prepare-dev-environment/gradle-cache/Dockerfile
+++ b/docker/prepare-dev-environment/gradle-cache/Dockerfile
@@ -1,5 +1,8 @@
 FROM ubuntu:jammy
 
+# Remove references to broken/outdated packages; otherwise we can get 404s:
+# E: Failed to fetch http://archive.ubuntu.com/ubuntu/pool/main/r/rsync/rsync_3.2.3-8ubuntu3.1_amd64.deb  404  Not Found [IP: 185.125.190.39 80
+RUN rm -rf /var/lib/apt/lists/*
 RUN apt -y -qq update
 RUN apt -y -qq install git openjdk-11-jdk rsync
 

--- a/docker/prepare-dev-environment/postgres/Dockerfile
+++ b/docker/prepare-dev-environment/postgres/Dockerfile
@@ -1,5 +1,8 @@
 FROM ubuntu:jammy
 
+# Remove references to broken/outdated packages; otherwise we can get 404s:
+# E: Failed to fetch http://archive.ubuntu.com/ubuntu/pool/main/r/rsync/rsync_3.2.3-8ubuntu3.1_amd64.deb  404  Not Found [IP: 185.125.190.39 80
+RUN rm -rf /var/lib/apt/lists/*
 RUN apt -y -qq update
 RUN apt -y -qq install wget gnupg lsb-core
 # https://www.postgresql.org/download/linux/ubuntu/

--- a/docker/prepare-dev-environment/solr/Dockerfile
+++ b/docker/prepare-dev-environment/solr/Dockerfile
@@ -1,5 +1,8 @@
 FROM ubuntu:jammy
 
+# Remove references to broken/outdated packages; otherwise we can get 404s:
+# E: Failed to fetch http://archive.ubuntu.com/ubuntu/pool/main/r/rsync/rsync_3.2.3-8ubuntu3.1_amd64.deb  404  Not Found [IP: 185.125.190.39 80
+RUN rm -rf /var/lib/apt/lists/*
 RUN apt -y -qq update
 # Beware! Python 3 is required by index-bioentities but comes as part of Ubuntu
 RUN apt -y -qq install git openjdk-11-jdk jq rsync curl

--- a/docker/prepare-dev-environment/volumes/Dockerfile
+++ b/docker/prepare-dev-environment/volumes/Dockerfile
@@ -1,5 +1,8 @@
 FROM ubuntu:jammy
 
+# Remove references to broken/outdated packages; otherwise we can get 404s:
+# E: Failed to fetch http://archive.ubuntu.com/ubuntu/pool/main/r/rsync/rsync_3.2.3-8ubuntu3.1_amd64.deb  404  Not Found [IP: 185.125.190.39 80
+RUN rm -rf /var/lib/apt/lists/*
 RUN apt -y -qq update
 RUN apt -y -qq install lftp
 


### PR DESCRIPTION
In a nutshell:
- Gene search results have been trimmed and only experiments where the searched genes are marker genes are returned
- *Homo sapiens* is the default species to avoid timeouts or excessive waiting for the majority of users
- The Ensembl ID example has been changed to one that won’t error out (the previous one would work after caching)

Besides some tweaks and fixes that I didn’t want to get lost (more specifically changes in our Docker files).