### PR TITLE
Number of assays column always empty bug fix

### DIFF
--- a/app/src/main/javascript/bundles/gene-search/src/ExperimentCard.js
+++ b/app/src/main/javascript/bundles/gene-search/src/ExperimentCard.js
@@ -1,8 +1,10 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
-import format from 'format-number'
+import formatNumber from 'format-number'
 import EbiSpeciesIcon from '@ebi-gene-expression-group/react-ebi-species'
+
+const _formatNumber = formatNumber()
 
 const CardContainerDiv = styled.div`
   height: 100%;
@@ -91,7 +93,7 @@ class ExperimentCard extends React.Component {
             {factors.map(factor => <li key={`factor-${factor}`}> {factor} </li>)}
           </ul>
         </VariableDiv>
-        <CountDiv> {format(numberOfAssays)} </CountDiv>
+        <CountDiv> {_formatNumber(numberOfAssays)}</CountDiv>
       </CardContainerDiv>
     )
   }


### PR DESCRIPTION
Story reference -  [Number of assays column always empty](https://github.com/ebi-gene-expression-group/atlas-web-single-cell/issues/331)

- Small fix in the javascript file -  `Experiments.js `
- Tested in my local by regenerating js bundles. I could see the number of assays column values in my local application.