### PR TITLE
Add url decoder for cell type heatmap search

### DIFF
--- a/app/src/main/java/uk/ac/ebi/atlas/search/metadata/JsonMultiexperimentCellTypeMarkerGenesController.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/search/metadata/JsonMultiexperimentCellTypeMarkerGenesController.java
@@ -9,8 +9,8 @@ import org.springframework.web.bind.annotation.RestController;
 import uk.ac.ebi.atlas.controllers.JsonExceptionHandlingController;
 import uk.ac.ebi.atlas.experimentpage.markergenes.HighchartsHeatmapAdapter;
 
-import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 
 import static uk.ac.ebi.atlas.utils.GsonProvider.GSON;
@@ -32,15 +32,13 @@ public class JsonMultiexperimentCellTypeMarkerGenesController extends JsonExcept
     public String getCellTypeMarkerGenes(
             @PathVariable String cellType,
             @RequestParam(name = "experiment-accessions", required = false) Collection<String> experimentAccessions) {
-        try {
-            return GSON.toJson(
-                    highchartsHeatmapAdapter.getMarkerGeneHeatmapDataSortedLexicographically(
-                            experimentAccessions == null ?
-                                    multiexperimentCellTypeMarkerGenesService.getCellTypeMarkerGeneProfile( URLDecoder.decode(cellType, "UTF-8")) :
-                                    multiexperimentCellTypeMarkerGenesService.getCellTypeMarkerGeneProfile(
-                                            ImmutableSet.copyOf(experimentAccessions), URLDecoder.decode(cellType, "UTF-8"))));
-        } catch (UnsupportedEncodingException e) {
-            return "Error decoding the URL: " + e.getMessage();
-        }
+        return GSON.toJson(
+                highchartsHeatmapAdapter.getMarkerGeneHeatmapDataSortedLexicographically(
+                        experimentAccessions == null ?
+                                multiexperimentCellTypeMarkerGenesService.getCellTypeMarkerGeneProfile(
+                                        URLDecoder.decode(cellType, StandardCharsets.UTF_8)) :
+                                multiexperimentCellTypeMarkerGenesService.getCellTypeMarkerGeneProfile(
+                                        ImmutableSet.copyOf(experimentAccessions),
+                                        URLDecoder.decode(cellType, StandardCharsets.UTF_8))));
     }
 }

--- a/app/src/main/java/uk/ac/ebi/atlas/search/metadata/JsonMultiexperimentCellTypeMarkerGenesController.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/search/metadata/JsonMultiexperimentCellTypeMarkerGenesController.java
@@ -9,6 +9,8 @@ import org.springframework.web.bind.annotation.RestController;
 import uk.ac.ebi.atlas.controllers.JsonExceptionHandlingController;
 import uk.ac.ebi.atlas.experimentpage.markergenes.HighchartsHeatmapAdapter;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
 import java.util.Collection;
 
 import static uk.ac.ebi.atlas.utils.GsonProvider.GSON;
@@ -30,11 +32,15 @@ public class JsonMultiexperimentCellTypeMarkerGenesController extends JsonExcept
     public String getCellTypeMarkerGenes(
             @PathVariable String cellType,
             @RequestParam(name = "experiment-accessions", required = false) Collection<String> experimentAccessions) {
-        return GSON.toJson(
-                highchartsHeatmapAdapter.getMarkerGeneHeatmapDataSortedLexicographically(
-                        experimentAccessions == null ?
-                                multiexperimentCellTypeMarkerGenesService.getCellTypeMarkerGeneProfile(cellType) :
-                                multiexperimentCellTypeMarkerGenesService.getCellTypeMarkerGeneProfile(
-                                        ImmutableSet.copyOf(experimentAccessions), cellType)));
+        try {
+            return GSON.toJson(
+                    highchartsHeatmapAdapter.getMarkerGeneHeatmapDataSortedLexicographically(
+                            experimentAccessions == null ?
+                                    multiexperimentCellTypeMarkerGenesService.getCellTypeMarkerGeneProfile( URLDecoder.decode(cellType, "UTF-8")) :
+                                    multiexperimentCellTypeMarkerGenesService.getCellTypeMarkerGeneProfile(
+                                            ImmutableSet.copyOf(experimentAccessions), URLDecoder.decode(cellType, "UTF-8"))));
+        } catch (UnsupportedEncodingException e) {
+            return "Error decoding the URL: " + e.getMessage();
+        }
     }
 }

--- a/app/src/test/java/uk/ac/ebi/atlas/search/metadata/JsonMultiexperimentCellTypeMarkerGenesControllerWIT.java
+++ b/app/src/test/java/uk/ac/ebi/atlas/search/metadata/JsonMultiexperimentCellTypeMarkerGenesControllerWIT.java
@@ -14,6 +14,9 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 import uk.ac.ebi.atlas.configuration.TestConfig;
 
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
 import static org.hamcrest.Matchers.isA;
 import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.AFTER_TEST_METHOD;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -58,7 +61,20 @@ class JsonMultiexperimentCellTypeMarkerGenesControllerWIT {
     @Test
     void returnsAValidJsonPayloadForAValidCellType() throws Exception {
         this.mockMvc.perform(get("/json/cell-type-marker-genes/{cellType}", "cell cycle S phase")
-                .param("experimentAccession", "E-ENAD-53"))
+                        .param("experimentAccession", "E-ENAD-53"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8))
+                .andExpect(jsonPath("$[0].cellGroupValue", isA(String.class)))
+                .andExpect(jsonPath("$[0].value", isA(Number.class)))
+                .andExpect(jsonPath("$[0].cellGroupValueWhereMarker", isA(String.class)))
+                .andExpect(jsonPath("$[0].pValue", isA(Number.class)));
+    }
+
+    @Test
+    void shouldReturnsAValidJsonPayloadForACellTypeContainingAForwardSlash() throws Exception {
+        final String encodedCellType = URLEncoder.encode("cell cycle G2/M phase", StandardCharsets.UTF_8);
+        this.mockMvc.perform(get("/json/cell-type-marker-genes/{cellType}", encodedCellType)
+                        .param("experimentAccession", "E-ENAD-53"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8))
                 .andExpect(jsonPath("$[0].cellGroupValue", isA(String.class)))

--- a/app/src/test/java/uk/ac/ebi/atlas/search/metadata/JsonMultiexperimentCellTypeMarkerGenesControllerWIT.java
+++ b/app/src/test/java/uk/ac/ebi/atlas/search/metadata/JsonMultiexperimentCellTypeMarkerGenesControllerWIT.java
@@ -17,6 +17,8 @@ import uk.ac.ebi.atlas.configuration.TestConfig;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isA;
 import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.AFTER_TEST_METHOD;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -59,7 +61,7 @@ class JsonMultiexperimentCellTypeMarkerGenesControllerWIT {
     }
 
     @Test
-    void returnsAValidJsonPayloadForAValidCellType() throws Exception {
+    void shouldReturnAValidJsonPayloadForAValidCellType() throws Exception {
         this.mockMvc.perform(get("/json/cell-type-marker-genes/{cellType}", "cell cycle S phase")
                         .param("experimentAccession", "E-ENAD-53"))
                 .andExpect(status().isOk())
@@ -71,7 +73,7 @@ class JsonMultiexperimentCellTypeMarkerGenesControllerWIT {
     }
 
     @Test
-    void shouldReturnsAValidJsonPayloadForACellTypeContainingAForwardSlash() throws Exception {
+    void shouldReturnAValidJsonPayloadForACellTypeContainingAForwardSlash() throws Exception {
         final String encodedCellType = URLEncoder.encode("cell cycle G2/M phase", StandardCharsets.UTF_8);
         this.mockMvc.perform(get("/json/cell-type-marker-genes/{cellType}", encodedCellType)
                         .param("experimentAccession", "E-ENAD-53"))
@@ -84,9 +86,11 @@ class JsonMultiexperimentCellTypeMarkerGenesControllerWIT {
     }
 
     @Test
-    void returnsEmptyPayloadForAnInvalidCellType() throws Exception {
+    void shouldReturnEmptyPayloadForAnInvalidCellType() throws Exception {
         this.mockMvc.perform(get("/json/cell-type-marker-genes/{cellType}", "fooBar")
                 .param("experimentAccession", "E-CURD-4"))
-                .andExpect(status().isOk());
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8))
+                .andExpect(jsonPath("$", is(empty())));
     }
 }


### PR DESCRIPTION
This PR has been merged to develop and closed. But during so many changes in the develop Branch, fix code has been removed or something messed up with the fix. So, fix is not working.





I deal with the `/` character in cell type value in the json endpoint as a request parameter.

