### PR TITLE
Update SQL for non-priority case in cell plot

### DIFF
--- a/app/src/main/java/uk/ac/ebi/atlas/experimentpage/cellplot/CellPlotDao.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/experimentpage/cellplot/CellPlotDao.java
@@ -157,14 +157,15 @@ public class CellPlotDao {
 
 
     private static final String SELECT_DEFAULT_PLOT_METHOD_AND_PARAMETERISATION =
-            "SELECT dr.method, jsonb_array_elements(dr.parameterisation) parameterisation " +
+            "SELECT DISTINCT dr.method, jsonb_array_elements(dr.parameterisation) parameterisation " +
                     "FROM scxa_dimension_reduction dr " +
                     "JOIN (SELECT method,  max(priority) as prt " +
                         "FROM scxa_dimension_reduction " +
                         "WHERE experiment_accession=:experiment_accession " +
                         " GROUP BY method) fi " +
                     "ON dr.method = fi.method " +
-                    "AND dr.priority = fi.prt";
+                    "AND dr.priority = fi.prt " +
+            "ORDER BY parameterisation";
 
     public Map<String, List<JsonObject>> fetchDefaultPlotMethodWithParameterisation(String experimentAccession) {
         var namedParameters = ImmutableMap.of("experiment_accession", experimentAccession);

--- a/app/src/main/java/uk/ac/ebi/atlas/experimentpage/cellplot/CellPlotDao.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/experimentpage/cellplot/CellPlotDao.java
@@ -165,6 +165,7 @@ public class CellPlotDao {
                         " GROUP BY method) fi " +
                     "ON dr.method = fi.method " +
                     "AND dr.priority = fi.prt " +
+            "WHERE experiment_accession=:experiment_accession " +
             "ORDER BY parameterisation";
 
     public Map<String, List<JsonObject>> fetchDefaultPlotMethodWithParameterisation(String experimentAccession) {

--- a/app/src/test/java/uk/ac/ebi/atlas/experimentpage/cellplot/CellPlotDaoIT.java
+++ b/app/src/test/java/uk/ac/ebi/atlas/experimentpage/cellplot/CellPlotDaoIT.java
@@ -173,15 +173,7 @@ class CellPlotDaoIT {
                         parameterisation))
                 .allSatisfy(dto -> assertThat(dto).hasFieldOrPropertyWithValue("expressionLevel", 0.0));
     }
-
-    @Test
-    void fetchDefaultPlotMethodAndParameterisationForTheExistingExperiment() {
-        var defaultPlotMethodResult = subject.fetchDefaultPlotMethodWithParameterisation(
-                jdbcTestUtils.fetchExperimentAccessionByMaxPriority());
-
-        assertThat(defaultPlotMethodResult.keySet()).containsExactlyInAnyOrder("UMAP","t-SNE");
-    }
-
+    
     @Test
     void fetchEmptyResultsIfExperimentDoesNotHaveDefaultPlotMethod(){
         assertThat(subject.fetchDefaultPlotMethodWithParameterisation("fooBar"))

--- a/app/src/test/java/uk/ac/ebi/atlas/experimentpage/cellplot/CellPlotDaoIT.java
+++ b/app/src/test/java/uk/ac/ebi/atlas/experimentpage/cellplot/CellPlotDaoIT.java
@@ -179,7 +179,7 @@ class CellPlotDaoIT {
         var defaultPlotMethodResult = subject.fetchDefaultPlotMethodWithParameterisation(
                 jdbcTestUtils.fetchExperimentAccessionByMaxPriority());
 
-        assertThat(defaultPlotMethodResult.keySet()).containsExactlyInAnyOrder("umap","tsne");
+        assertThat(defaultPlotMethodResult.keySet()).containsExactlyInAnyOrder("UMAP","t-SNE");
     }
 
     @Test

--- a/app/src/test/java/uk/ac/ebi/atlas/experimentpage/cellplot/CellPlotDaoIT.java
+++ b/app/src/test/java/uk/ac/ebi/atlas/experimentpage/cellplot/CellPlotDaoIT.java
@@ -179,7 +179,7 @@ class CellPlotDaoIT {
         var defaultPlotMethodResult = subject.fetchDefaultPlotMethodWithParameterisation(
                 jdbcTestUtils.fetchExperimentAccessionByMaxPriority());
 
-        assertThat(defaultPlotMethodResult.keySet()).contains("umap","tsne");
+        assertThat(defaultPlotMethodResult.keySet()).containsExactlyInAnyOrder("umap","tsne");
     }
 
     @Test


### PR DESCRIPTION
This a bugfix related to the issue https://github.com/ebi-gene-expression-group/atlas-web-single-cell/issues/374.

In the previous implementation, we suppose at least one highest `priority` value, i.e. larger than `0`, would be curated in the table `scxa-dimension-reduction`. However, due to lack of enough data or curated by mistakes, we do not always have the highest `prioriy` value, so I fix the postgres query to select proper entries in both cases. 

There are some data populating issues on dev PostgreSQL database, which has been reported to data production team members on Slack. Please follow the updates via https://ebi-fg.slack.com/archives/C7U2CRS58/p1706111909985499.