### PR TITLE
[Bugfix] Fix failing unit tests

### DIFF
--- a/app/src/test/java/uk/ac/ebi/atlas/configuration/TestConfigForHCA.java
+++ b/app/src/test/java/uk/ac/ebi/atlas/configuration/TestConfigForHCA.java
@@ -1,0 +1,92 @@
+package uk.ac.ebi.atlas.configuration;
+
+import com.google.common.collect.ImmutableSet;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.ComponentScan.Filter;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.web.client.RestTemplate;
+import uk.ac.ebi.atlas.hcalandingpage.HcaHumanExperimentDao;
+import uk.ac.ebi.atlas.hcalandingpage.HcaHumanExperimentService;
+import uk.ac.ebi.atlas.model.experiment.ExperimentType;
+import uk.ac.ebi.atlas.solr.cloud.SolrCloudCollectionProxyFactory;
+import uk.ac.ebi.atlas.species.SpeciesFinder;
+import uk.ac.ebi.atlas.trader.ExperimentTrader;
+import uk.ac.ebi.atlas.utils.BioentityIdentifiersReader;
+
+import java.util.HashSet;
+import java.util.Set;
+
+@Configuration
+// Enabling component scanning will also load BasePathsConfig, JdbcConfig and SolrConfig, so just using this class as
+// application context is enough in integration tests. It’s important to exclude CacheConfig, otherwise Spring will
+// complain if you want to inject classes such as ScxaExperimentTrader, since a proxy will be injected instead! As an
+// exercise, remove CacheConfig.class and run tests in ScxaExperimentTraderIT.
+@ComponentScan(basePackages = "uk.ac.ebi.atlas",
+               excludeFilters = @Filter(type = FilterType.ASSIGNABLE_TYPE,
+                                        value = {AppConfig.class, CacheConfig.class}))
+public class TestConfigForHCA {
+
+    private static final String INVALID_CHARACTERISTIC_VALUE = "foo";
+    private static final String VALID_CHARACTERISTIC_VALUE = "pancreas";
+
+    private static final ImmutableSet<String> ALL_ACCESSION_IDS =
+            ImmutableSet.of("E-CURD-4", "E-EHCA-2", "E-GEOD-71585", "E-GEOD-81547", "E-GEOD-99058", "E-MTAB-5061",
+                    "E-ENAD-53");
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+
+    @Bean
+    public BioentityIdentifiersReader bioentityIdentifiersReader() {
+        return new BioentityIdentifiersReader() {
+            @Override
+            protected int addBioentityIdentifiers(HashSet<String> bioentityIdentifiers, ExperimentType experimentType) {
+                return 0;
+            }
+
+            @Override
+            public HashSet<String> getBioentityIdsFromExperiment(String experimentAccession) {
+                return new HashSet<>();
+            }
+
+            @Override
+            public HashSet<String> getBioentityIdsFromExperiment(String experimentAccession, boolean throwError) {
+                return new HashSet<>();
+            }
+        };
+    }
+
+    @Bean
+    public SpeciesFinder speciesFinder() {
+        return new SpeciesFinder() {};
+    }
+
+    @Bean
+    public HcaHumanExperimentDao hcaHumanExperimentDao(SolrCloudCollectionProxyFactory solrCloudCollectionProxyFactory) {
+
+        return new HcaHumanExperimentDao(solrCloudCollectionProxyFactory) {
+
+            @Override
+            public ImmutableSet<String> fetchExperimentAccessions(String characteristicName,
+                                                                  Set<String> characteristicValues) {
+                if (characteristicValues.contains(INVALID_CHARACTERISTIC_VALUE)) {
+                    return ImmutableSet.of();
+                } else if(characteristicValues.contains(VALID_CHARACTERISTIC_VALUE)) {
+                    return ImmutableSet.of("E-MTAB-5061");
+                } else {
+                    return ALL_ACCESSION_IDS;
+                }
+            }
+        };
+    }
+
+    @Bean
+    public HcaHumanExperimentService hcaHumanExperimentService(ExperimentTrader experimentTrader,
+                                                               HcaHumanExperimentDao hcaHumanExperimentDao) {
+        return new HcaHumanExperimentService(experimentTrader, hcaHumanExperimentDao);
+    }
+}

--- a/app/src/test/java/uk/ac/ebi/atlas/configuration/TestConfigForHCA.java
+++ b/app/src/test/java/uk/ac/ebi/atlas/configuration/TestConfigForHCA.java
@@ -6,16 +6,11 @@ import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.ComponentScan.Filter;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.FilterType;
-import org.springframework.web.client.RestTemplate;
 import uk.ac.ebi.atlas.hcalandingpage.HcaHumanExperimentDao;
 import uk.ac.ebi.atlas.hcalandingpage.HcaHumanExperimentService;
-import uk.ac.ebi.atlas.model.experiment.ExperimentType;
 import uk.ac.ebi.atlas.solr.cloud.SolrCloudCollectionProxyFactory;
-import uk.ac.ebi.atlas.species.SpeciesFinder;
 import uk.ac.ebi.atlas.trader.ExperimentTrader;
-import uk.ac.ebi.atlas.utils.BioentityIdentifiersReader;
 
-import java.util.HashSet;
 import java.util.Set;
 
 @Configuration
@@ -26,7 +21,7 @@ import java.util.Set;
 @ComponentScan(basePackages = "uk.ac.ebi.atlas",
                excludeFilters = @Filter(type = FilterType.ASSIGNABLE_TYPE,
                                         value = {AppConfig.class, CacheConfig.class}))
-public class TestConfigForHCA {
+public class TestConfigForHCA extends TestConfig {
 
     private static final String INVALID_CHARACTERISTIC_VALUE = "foo";
     private static final String VALID_CHARACTERISTIC_VALUE = "pancreas";
@@ -34,36 +29,6 @@ public class TestConfigForHCA {
     private static final ImmutableSet<String> ALL_ACCESSION_IDS =
             ImmutableSet.of("E-CURD-4", "E-EHCA-2", "E-GEOD-71585", "E-GEOD-81547", "E-GEOD-99058", "E-MTAB-5061",
                     "E-ENAD-53");
-
-    @Bean
-    public RestTemplate restTemplate() {
-        return new RestTemplate();
-    }
-
-    @Bean
-    public BioentityIdentifiersReader bioentityIdentifiersReader() {
-        return new BioentityIdentifiersReader() {
-            @Override
-            protected int addBioentityIdentifiers(HashSet<String> bioentityIdentifiers, ExperimentType experimentType) {
-                return 0;
-            }
-
-            @Override
-            public HashSet<String> getBioentityIdsFromExperiment(String experimentAccession) {
-                return new HashSet<>();
-            }
-
-            @Override
-            public HashSet<String> getBioentityIdsFromExperiment(String experimentAccession, boolean throwError) {
-                return new HashSet<>();
-            }
-        };
-    }
-
-    @Bean
-    public SpeciesFinder speciesFinder() {
-        return new SpeciesFinder() {};
-    }
 
     @Bean
     public HcaHumanExperimentDao hcaHumanExperimentDao(SolrCloudCollectionProxyFactory solrCloudCollectionProxyFactory) {

--- a/app/src/test/java/uk/ac/ebi/atlas/experimentimport/idf/IdfParserForSingleCellIT.java
+++ b/app/src/test/java/uk/ac/ebi/atlas/experimentimport/idf/IdfParserForSingleCellIT.java
@@ -17,7 +17,6 @@ import uk.ac.ebi.atlas.testutils.JdbcUtils;
 
 import javax.inject.Inject;
 import javax.sql.DataSource;
-import java.nio.file.Path;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -25,7 +24,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @ContextConfiguration(classes = TestConfig.class)
 @WebAppConfiguration
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-class IdfParserIT {
+class IdfParserForSingleCellIT {
     @Inject
     private DataSource dataSource;
 

--- a/app/src/test/java/uk/ac/ebi/atlas/hcalandingpage/HcaHumanExperimentsControllerWIT.java
+++ b/app/src/test/java/uk/ac/ebi/atlas/hcalandingpage/HcaHumanExperimentsControllerWIT.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.http.MediaType;
@@ -16,7 +17,7 @@ import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
-import uk.ac.ebi.atlas.configuration.TestConfig;
+import uk.ac.ebi.atlas.configuration.TestConfigForHCA;
 
 import javax.inject.Inject;
 import javax.sql.DataSource;
@@ -26,9 +27,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@ExtendWith(SpringExtension.class)
+@ExtendWith({MockitoExtension.class, SpringExtension.class})
 @WebAppConfiguration
-@ContextConfiguration(classes = TestConfig.class)
+@ContextConfiguration(classes = TestConfigForHCA.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class HcaHumanExperimentsControllerWIT {
     @Inject


### PR DESCRIPTION
Changes:
- Remove large experiment from atlas-web-core module that using `bulk` experiments
- Add flexibility for HCA experiment controller's test
- Rename non identically named test class: Both atlas-web-single-cell and atlas-web-core repository contained a test class with the same package and class name.

Accompanied PR from atlas-web-core: [[bugfix] Remove large experiments from fixtures and unit tests](https://github.com/ebi-gene-expression-group/atlas-web-core/pull/132).