### PR TITLE
Add consistency between cell plots tab and marker genes tab

### DIFF
--- a/app/src/main/javascript/bundles/experiment-page/src/TSnePlotViewRoute.js
+++ b/app/src/main/javascript/bundles/experiment-page/src/TSnePlotViewRoute.js
@@ -29,7 +29,7 @@ RedirectWithSearchAndHash.propTypes = {
 const RedirectWithLocation = withRouter(RedirectWithSearchAndHash)
 
 const CLUSTERS_PLOT = `clusters`
-const METADATA_PLOT = `metatdata`
+const METADATA_PLOT = `metadata`
 
 class TSnePlotViewRoute extends React.Component {
   constructor(props) {

--- a/app/src/main/javascript/bundles/experiment-page/src/TSnePlotViewRoute.js
+++ b/app/src/main/javascript/bundles/experiment-page/src/TSnePlotViewRoute.js
@@ -49,12 +49,12 @@ class TSnePlotViewRoute extends React.Component {
     const { species, experimentAccession, accessKey, ks, ksWithMarkerGenes, plotTypesAndOptions, metadata, anatomogram } = this.props
     const search = URI(location.search).search(true)
 
-let plotTypeDropdown =
-        Object.keys(defaultPlotMethodAndParameterisation)
-            .map(plot => ({
-              plotType: plot,
-              plotOptions: plotTypesAndOptions[plot]
-            }));
+    let plotTypeDropdown =
+      Object.keys(defaultPlotMethodAndParameterisation)
+        .map(plot => ({
+          plotType: plot,
+          plotOptions: plotTypesAndOptions[plot]
+        }))
 
     let organWithMostOntologies = Object.keys(anatomogram)[0]
     for (let availableOrgan in anatomogram) {

--- a/app/src/main/javascript/bundles/experiment-page/src/TSnePlotViewRoute.js
+++ b/app/src/main/javascript/bundles/experiment-page/src/TSnePlotViewRoute.js
@@ -99,10 +99,7 @@ class TSnePlotViewRoute extends React.Component {
           height={800}
           onSelectGeneId={
             (geneId) => {
-              const query = new URLSearchParams(history.location.search)
-              query.set(`geneId`, geneId)
-              resetHighlightClusters(query)
-              updateUrlWithParams(query)
+              updateUrlWithParams([{geneId: geneId}])
             }
           }
           plotTypeDropdown={plotTypeDropdown}
@@ -125,11 +122,7 @@ class TSnePlotViewRoute extends React.Component {
                     + ": " + Object.values(defaultPlotMethodAndParameterisation[plotOption.value])[0],
               })
 
-              const query = new URLSearchParams(history.location.search)
-              query.set(`plotType`, plotOption.value)
-              query.set(`plotOption`, Object.values(defaultPlotMethodAndParameterisation[plotOption.value])[0])
-              resetHighlightClusters(query)
-              updateUrlWithParams(query)
+              updateUrlWithParams([{plotType: plotOption.value}, {plotOption: Object.values(defaultPlotMethodAndParameterisation[plotOption.value])[0]}])
               }
           }
           onChangePlotOptions={
@@ -138,10 +131,7 @@ class TSnePlotViewRoute extends React.Component {
                 selectedPlotOption: plotOption.value,
                 selectedPlotOptionLabel: plotOption.label
               })
-              const query = new URLSearchParams(history.location.search)
-              query.set(`plotOption`, plotOption.value)
-              resetHighlightClusters(query)
-              updateUrlWithParams(query)
+              updateUrlWithParams([{plotOption: plotOption.value}])
               }
           }
 
@@ -154,11 +144,9 @@ class TSnePlotViewRoute extends React.Component {
               colourByCategory === CLUSTERS_PLOT && this.setState({
               selectedClusterId : colourByValue
             })
-            const query = new URLSearchParams(history.location.search)
-            query.set(`colourBy`, colourByValue)
-            colourByCategory === CLUSTERS_PLOT && query.set(`k`, colourByValue)
-            resetHighlightClusters(query)
-            updateUrlWithParams(query)
+              const queryParams = [{colourBy: colourByValue}]
+              colourByCategory === CLUSTERS_PLOT && queryParams.push({k: colourByValue})
+              updateUrlWithParams(queryParams)
             }
           }
         />
@@ -187,12 +175,8 @@ class TSnePlotViewRoute extends React.Component {
                 selectedColourBy : colourByValue,
                 selectedColourByCategory : CLUSTERS_PLOT
               })
-              const query = new URLSearchParams(history.location.search)
               // If tsne plot is coloured by k
-              query.set(`k`, colourByValue)
-              query.set(`colourBy`, colourByValue)
-              resetHighlightClusters(query)
-              updateUrlWithParams(query)
+              updateUrlWithParams([{k: colourByValue}, {colourBy: colourByValue}])
             }
           }
           onChangeMarkerGeneFor={(selectedOption) => {
@@ -227,7 +211,7 @@ class TSnePlotViewRoute extends React.Component {
       }
     ]
 
-    const updateUrlWithParams = (query) => {
+    const updateUrl = (query) => {
       history.push({...history.location, search: query.toString()})
     }
 
@@ -235,6 +219,13 @@ class TSnePlotViewRoute extends React.Component {
       if(query.has(`clusterId`)) {
         query.delete(`clusterId`)
       }
+    }
+
+    const updateUrlWithParams = (params) => {
+      const query = new URLSearchParams(history.location.search)
+      params.forEach(param => query.set(Object.keys(param)[0], Object.values(param)[0]))
+      resetHighlightClusters(query)
+      updateUrl(query)
     }
 
     const preferredK = this.props.selectedK ? this.props.selectedK.toString() : this.props.ks[0].toString()

--- a/app/src/main/javascript/bundles/experiment-page/src/TSnePlotViewRoute.js
+++ b/app/src/main/javascript/bundles/experiment-page/src/TSnePlotViewRoute.js
@@ -49,12 +49,12 @@ class TSnePlotViewRoute extends React.Component {
     const { species, experimentAccession, accessKey, ks, ksWithMarkerGenes, plotTypesAndOptions, metadata, anatomogram } = this.props
     const search = URI(location.search).search(true)
 
-    let plotTypeDropdown =  []
-    Object.keys(defaultPlotMethodAndParameterisation).map(plot => plotTypeDropdown.push(
-    {
-      plotType: plot,
-          plotOptions: plotTypesAndOptions[plot]
-    }))
+let plotTypeDropdown =
+        Object.keys(defaultPlotMethodAndParameterisation)
+            .map(plot => ({
+              plotType: plot,
+              plotOptions: plotTypesAndOptions[plot]
+            }));
 
     let organWithMostOntologies = Object.keys(anatomogram)[0]
     for (let availableOrgan in anatomogram) {

--- a/app/src/main/javascript/bundles/experiment-page/src/TSnePlotViewRoute.js
+++ b/app/src/main/javascript/bundles/experiment-page/src/TSnePlotViewRoute.js
@@ -28,6 +28,9 @@ RedirectWithSearchAndHash.propTypes = {
 
 const RedirectWithLocation = withRouter(RedirectWithSearchAndHash)
 
+const CLUSTERS_PLOT = `clusters`
+const METADATA_PLOT = `metatdata`
+
 class TSnePlotViewRoute extends React.Component {
   constructor(props) {
       super(props)
@@ -42,7 +45,7 @@ class TSnePlotViewRoute extends React.Component {
       selectedColourBy: cellTypeValue ? cellTypeValue.toLowerCase() : this.props.ks[Math.round((this.props.ks.length -1) / 2)].toString(),
       highlightClusters: [],
       experimentAccession: this.props.experimentAccession,
-      selectedColourByCategory: isNaN(search.colourBy) ? `metadata` :  `clusters`,
+      selectedColourByCategory: isNaN(search.colourBy) ? METADATA_PLOT :  CLUSTERS_PLOT,
       selectedClusterId: cellTypeValue ? cellTypeValue.toLowerCase() : this.props.ks[Math.round((this.props.ks.length -1) / 2)].toString(),
       selectedClusterIdOption: ``
     }
@@ -74,7 +77,7 @@ class TSnePlotViewRoute extends React.Component {
 
     const routes = [
       {
-        path: `/tsne`,
+        path: `/cell-plots`,
         title: `Cell plots`,
         main: () => <TSnePlotView
           atlasUrl={atlasUrl}
@@ -104,14 +107,15 @@ class TSnePlotViewRoute extends React.Component {
           }
           plotTypeDropdown={plotTypeDropdown}
           selectedPlotOptionLabel={search.plotOption ?
-              search.plotType ?
-                  Object.keys(plotTypeDropdown[plotTypeDropdown.findIndex(
-                      (plot) => plot.plotType.toLowerCase() === search.plotType.toLowerCase())].plotOptions[0])[0] + `: ` + search.plotOption
-                  :
-                  Object.keys(plotTypeDropdown[plotTypeDropdown.findIndex(
-                      (plot) => plot.plotType.toLowerCase() ===  this.state.selectedPlotType.toLowerCase())].plotOptions[0])[0] + `: ` + search.plotOption
-              :
-              this.state.selectedPlotOptionLabel}
+                search.plotType ?
+                    Object.keys(plotTypeDropdown[plotTypeDropdown.findIndex(
+                        (plot) => plot.plotType.toLowerCase() === search.plotType.toLowerCase())].plotOptions[0])[0] + `: ` + search.plotOption
+                    :
+                    Object.keys(plotTypeDropdown[plotTypeDropdown.findIndex(
+                        (plot) => plot.plotType.toLowerCase() ===  this.state.selectedPlotType.toLowerCase())].plotOptions[0])[0] + `: ` + search.plotOption
+                :
+                this.state.selectedPlotOptionLabel
+          }
           onChangePlotTypes={
             (plotOption) => {
               this.setState({
@@ -147,8 +151,12 @@ class TSnePlotViewRoute extends React.Component {
                 selectedColourBy : colourByValue,
                 selectedColourByCategory : colourByCategory
               })
+              colourByCategory === CLUSTERS_PLOT && this.setState({
+              selectedClusterId : colourByValue
+            })
             const query = new URLSearchParams(history.location.search)
             query.set(`colourBy`, colourByValue)
+            colourByCategory === CLUSTERS_PLOT && query.set(`k`, colourByValue)
             resetHighlightClusters(query)
             updateUrlWithParams(query)
             }
@@ -172,14 +180,17 @@ class TSnePlotViewRoute extends React.Component {
           wrapperClassName={`row expanded`}
           ks={ks}
           selectedClusterByCategory={search.cellGroupType || search.k || preferredK}
-          selectedK={this.state.selectedClusterId}
+          selectedK={this.state.colourByCategory === CLUSTERS_PLOT ? this.state.selectedColourBy : this.state.selectedClusterId}
           onSelectK={(colourByValue) => {
               this.setState({
-                selectedClusterId : colourByValue
+                selectedClusterId : colourByValue,
+                selectedColourBy : colourByValue,
+                selectedColourByCategory : CLUSTERS_PLOT
               })
               const query = new URLSearchParams(history.location.search)
               // If tsne plot is coloured by k
               query.set(`k`, colourByValue)
+              query.set(`colourBy`, colourByValue)
               resetHighlightClusters(query)
               updateUrlWithParams(query)
             }


### PR DESCRIPTION
According to Silvie's detailed comments, I add logics to make cell plot & marker gene plot options are consistent when the plot type is `clusters`.

Besides, I refactored the tab name from `tsne` to `cell-plots` as discussed in some meetings before, so the tab refers to both tsne and umap plots more properly.