### PR TITLE
[chore] Add analysis description text for supplementary info in case of anndata

### DIFF
--- a/app/src/main/javascript/bundles/experiment-page/src/SupplementaryInformationRoute.js
+++ b/app/src/main/javascript/bundles/experiment-page/src/SupplementaryInformationRoute.js
@@ -15,11 +15,23 @@ const SectionContent = ({type, props, atlasUrl}) => {
 }
 
 const SupplementaryInformationRoute = (props) => {
+  const annDataText =
+      'This methods summary is based on information provided by the authors or described in the associated ' +
+      'publication, the data have not been re-analysed by Single Cell Expression Atlas'
+
   const sections = props.sections.map((section) =>
-    <div key={section.name}>
-      <h3>{section.name}</h3>
-      <SectionContent type={section.type} props={section.props} atlasUrl={props.atlasUrl} />
-    </div>
+    {
+      const isAnnDataTextNeeded =
+        props.experimentAccession.startsWith('E-ANND') && section.name === `Analysis Methods`
+
+      return (
+        <div key={section.name}>
+          <h3>{section.name}</h3>
+          { isAnnDataTextNeeded && <p><i>{annDataText}</i></p> }
+          <SectionContent type={section.type} props={section.props} atlasUrl={props.atlasUrl}/>
+        </div>
+      )
+    }
   )
 
   return (


### PR DESCRIPTION
We added a small explanatory text to the `Analysis Method` session of the `Supplementary Information` tab of an experiment in case of `anndata` experiment.