### PR TITLE
[Chore] Add no build flag to local deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,7 +43,6 @@ gradle-app.setting
 # Node gitignore from https://github.com/github/gitignore/blob/master/Node.gitignore
 # Logs
 logs
-*.log
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
@@ -145,3 +144,4 @@ _idea
 
 # Webpack bundles
 app/src/main/webapp/resources/js-bundles
+/app/src/main/javascript/bundles/*/lib/

--- a/build-and-deploy-webapp.sh
+++ b/build-and-deploy-webapp.sh
@@ -10,6 +10,7 @@ function show_usage {
   echo "It is building and deploying our web application."
   echo ""
   echo "All options are disabled if omitted."
+  echo -e "-n\tUse this flag if you would not like to do any build, just execute the application."
   echo -e "-f\tUse this flag if you would like to build the front-end javascript packages."
   echo -e "-b\tUse this flag if you would like to build the back-end of the web application."
   echo -e "-h\tDisplaying this help file."
@@ -23,11 +24,17 @@ function get_build_type() {
     echo "-war-only"
   elif [[ $BUILD_FRONTEND == "true" && $BUILD_BACKEND == "true" ]] || [[ -z $BUILD_FRONTEND && -z $BUILD_BACKEND ]]; then
     echo "-all"
+  elif [[ $BUILD_FRONTEND == "false" && $BUILD_BACKEND == "false" ]]; then
+    echo "-no"
   fi
 }
 
-while getopts ":fbh" opt; do
+while getopts ":bfhn" opt; do
   case $opt in
+    n)
+      BUILD_FRONTEND=false
+      BUILD_BACKEND=false
+      ;;
     f)
       BUILD_FRONTEND=true
       ;;

--- a/docker/docker-compose-build-all.yml
+++ b/docker/docker-compose-build-all.yml
@@ -15,6 +15,8 @@ services:
     extends:
       service: gradle
       file: docker-compose-gradle.yml
+    ports:
+      - "5005:5005"
     command: ["sh", "-c", "gradle clean :app:war"]
 
   gradle-shell:
@@ -27,17 +29,5 @@ services:
     depends_on:
       gradle-build:
         condition: service_completed_successfully
-
-  tomcat:
-    extends:
-      service: tomcat
-      file: docker-compose-tomcat.yml
-    depends_on:
-      gradle-build:
-        condition: service_completed_successfully
-      postgres:
-        condition: service_started
-      solrcloud-0:
-        condition: service_started
-      solrcloud-1:
-        condition: service_started
+    ports:
+      - "5006:5005"

--- a/docker/docker-compose-build-no.yml
+++ b/docker/docker-compose-build-no.yml
@@ -7,17 +7,15 @@ services:
       file: docker-compose-gradle.yml
     ports:
       - "5005:5005"
-    command: ["sh", "-c", "gradle clean :app:war"]
 
   gradle-shell:
     extends:
       service: gradle
       file: docker-compose-gradle.yml
+    networks:
+      - atlas-test-net
+    ports:
+      - "5006:5005"
     tty: true
     stdin_open: true
     command: [ "sh", "-c", "gradle && /bin/bash" ]
-    depends_on:
-      gradle-build:
-        condition: service_completed_successfully
-    ports:
-      - "5006:5005"

--- a/docker/docker-compose-build-ui-only.yml
+++ b/docker/docker-compose-build-ui-only.yml
@@ -15,6 +15,8 @@ services:
     extends:
       service: gradle
       file: docker-compose-gradle.yml
+    ports:
+      - "5005:5005"
 
   gradle-shell:
     extends:
@@ -26,17 +28,5 @@ services:
     depends_on:
       gradle-build:
         condition: service_completed_successfully
-
-  tomcat:
-    extends:
-      service: tomcat
-      file: docker-compose-tomcat.yml
-    depends_on:
-      gradle-build:
-        condition: service_completed_successfully
-      postgres:
-        condition: service_started
-      solrcloud-0:
-        condition: service_started
-      solrcloud-1:
-        condition: service_started
+    ports:
+      - "5006:5005"

--- a/docker/docker-compose-gradle-test.yml
+++ b/docker/docker-compose-gradle-test.yml
@@ -1,0 +1,42 @@
+version: "3.6"
+
+services:
+  gradle:
+    image: gradle:7.0-jdk11
+    networks:
+      - atlas-test-net
+    ports:
+      - "5005:5005"
+    volumes:
+      - ..:/root/project
+      - gradle-wrapper-dists:/root/.gradle/wrapper/dists
+      - gradle-ro-dep-cache:/gradle-ro-dep-cache:ro
+      - bioentity-properties:/atlas-data/bioentity_properties:ro
+      - exp:/atlas-data/exp:ro
+      - expdesign:/atlas-data/expdesign
+    depends_on:
+      scxa-solrcloud-0:
+        condition: service_started
+      solrcloud-1:
+        condition: service_started
+      flyway:
+        condition: service_completed_successfully
+    environment:
+      GRADLE_RO_DEP_CACHE: /gradle-ro-dep-cache
+    working_dir: /root/project
+
+volumes:
+  gradle-wrapper-dists:
+    name: ${PROJECT_NAME}_${GRADLE_WRAPPER_DISTS_VOL_NAME}
+  gradle-ro-dep-cache:
+    name: ${PROJECT_NAME}_${GRADLE_RO_DEP_CACHE_VOL_NAME}
+  bioentity-properties:
+    name: ${PROJECT_NAME}_${ATLAS_DATA_BIOENTITY_PROPERTIES_VOL_NAME}
+  exp:
+    name: ${PROJECT_NAME}_${ATLAS_DATA_EXP_VOL_NAME}
+  expdesign:
+    name: ${PROJECT_NAME}_${ATLAS_DATA_EXPDESIGN_VOL_NAME}
+
+networks:
+  atlas-test-net:
+    name: atlas-test-net

--- a/docker/prepare-dev-environment/postgres/docker-compose.yml
+++ b/docker/prepare-dev-environment/postgres/docker-compose.yml
@@ -101,6 +101,7 @@ volumes:
     external: true
     name: ${PROJECT_NAME}_${ATLAS_DATA_EXP_VOL_NAME}
   atlas-data-expdesign:
+    external: true
     name: ${PROJECT_NAME}_${ATLAS_DATA_EXPDESIGN_VOL_NAME}
 
 networks:


### PR DESCRIPTION
Add the `-n` parameter to the `build-and-deploy-webapp.sh` shell script to be able to startup the application without UI and/or backend build. We already have this option in `bulk` I just ported it to `single cell` web app.