### PR TITLE
[Bugfix] Fix processing search data for cell type wheel

### DIFF
--- a/app/src/test/java/uk/ac/ebi/atlas/search/metadata/HighchartsSunburstAdapterTest.java
+++ b/app/src/test/java/uk/ac/ebi/atlas/search/metadata/HighchartsSunburstAdapterTest.java
@@ -1,20 +1,21 @@
 package uk.ac.ebi.atlas.search.metadata;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import org.apache.commons.lang3.tuple.ImmutablePair;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.ac.ebi.atlas.species.Species;
-import uk.ac.ebi.atlas.testutils.RandomDataTestUtils;
 
+import java.util.List;
+import java.util.stream.IntStream;
+
+import static java.util.stream.Collectors.toList;
 import static org.apache.commons.lang3.RandomStringUtils.randomAlphabetic;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.mockito.Mockito.when;
 import static uk.ac.ebi.atlas.testutils.RandomDataTestUtils.generateRandomExperimentAccession;
 import static uk.ac.ebi.atlas.testutils.RandomDataTestUtils.generateRandomSpecies;
@@ -23,92 +24,156 @@ import static uk.ac.ebi.atlas.testutils.RandomDataTestUtils.generateRandomSpecie
 class HighchartsSunburstAdapterTest {
     @Mock
     private CellTypeWheelService cellTypeWheelServiceMock;
-    private HighchartsSunburstAdapter subject;
-    private String metadataSearchTerm =  randomAlphabetic(20);
-    private Species species1 = generateRandomSpecies();
+    private final HighchartsSunburstAdapter subject = new HighchartsSunburstAdapter();
 
-    @BeforeEach
-    void setUp() {
-        subject = new HighchartsSunburstAdapter();
-        var species1OrganismPart1 = randomAlphabetic(10);
-        var species1OrganismPart1CellType1 = randomAlphabetic(30);
-        var species1OrganismPart1ExperimentAccession = generateRandomExperimentAccession();
-        var species1OrganismPart1CellType2 = randomAlphabetic(30);
-        var species1OrganismPart1CellType3 = randomAlphabetic(30);
-        var species1OrganismPart2 = randomAlphabetic(10);
-        var species1OrganismPart2CellType1 = randomAlphabetic(30);
-        var species1OrganismPart2ExperimentAccession = generateRandomExperimentAccession();
+    @Test
+    void whenSearchTermFoundAndNotFilteringBySpecies_ThenReturnResult() {
+        var species = generateSpecies(1);
+        var speciesName = species.get(0).getName();
 
-        when(cellTypeWheelServiceMock.search(metadataSearchTerm, species1.getName()))
-                .thenReturn(
-                        // Species
-                        ImmutableSet.of(ImmutablePair.of(
-                                ImmutableList.of(species1.getName()),
-                                species1OrganismPart1ExperimentAccession)),
-                        ImmutableSet.of(ImmutablePair.of(
-                                ImmutableList.of(species1.getName()),
-                                species1OrganismPart2ExperimentAccession)),
+        when(cellTypeWheelServiceMock.search(speciesName, null))
+                .thenReturn(getSearchResultForASpecies(species));
+
+        var result = subject.getCellTypeWheelSunburst(speciesName,
+                cellTypeWheelServiceMock.search(speciesName, null));
+        assertThat(result.isEmpty()).isFalse();
+
+        final ImmutableList<ImmutableMap<String, ?>> resultAsList = result.asList();
+        var centreRingElement = resultAsList.get(0);
+        assertThat(centreRingElement.get("parent")).isEqualTo("");
+        assertThat((ImmutableSet<String>) centreRingElement.get("experimentAccessions")).isNotEmpty();
+
+        assertRemainingRingElements(resultAsList);
+    }
+
+    @Test
+    void whenSearchTermFoundAndFilteringBySpecies_ThenReturnResult() {
+        var species = generateSpecies(1);
+        var speciesName = species.get(0).getName();
+
+        when(cellTypeWheelServiceMock.search(speciesName, speciesName))
+                .thenReturn(getSearchResultForASpecies(species));
+
+        var result = subject.getCellTypeWheelSunburst(speciesName,
+                cellTypeWheelServiceMock.search(speciesName, speciesName));
+        assertThat(result.isEmpty()).isFalse();
+
+        final ImmutableList<ImmutableMap<String, ?>> resultAsList = result.asList();
+        var centreRingElement = resultAsList.get(0);
+        assertThat(centreRingElement.get("parent")).isEqualTo("");
+        assertThat((ImmutableSet<String>) centreRingElement.get("experimentAccessions")).isNotEmpty();
+
+        assertRemainingRingElements(resultAsList);
+        assertAllResultsParentIsGivenSpecies(speciesName, resultAsList);
+    }
+
+    @Test
+    void whenNotFilteringBySpeciesAndSearchTermIsNotFound_ThenReturnEmptyResult() {
+        final String searchTermNotInDatabase = "searchTermNotInDatabase";
+        when(cellTypeWheelServiceMock.search(searchTermNotInDatabase, null))
+                .thenReturn(ImmutableSet.of());
+        var result = subject.getCellTypeWheelSunburst(searchTermNotInDatabase,
+                cellTypeWheelServiceMock.search(searchTermNotInDatabase, null));
+
+        assertThat(result.isEmpty()).isTrue();
+    }
+
+    @Test
+    void whenFilteringBySpeciesButSearchTermIsNotFound_ThenReturnEmptyResult() {
+        final String searchTermNotInDatabase = "searchTermNotInDatabase";
+        when(cellTypeWheelServiceMock.search(searchTermNotInDatabase, null))
+                .thenReturn(ImmutableSet.of());
+        var result = subject.getCellTypeWheelSunburst(searchTermNotInDatabase,
+                cellTypeWheelServiceMock.search(searchTermNotInDatabase, null));
+
+        assertThat(result.isEmpty()).isTrue();
+    }
+
+
+    private void assertRemainingRingElements(ImmutableList<ImmutableMap<String, ?>> resultAsList) {
+        resultAsList.subList(1, resultAsList.size()).forEach(element -> {
+            var name = element.get("name");
+            var id = element.get("id");
+            var parent = element.get("parent");
+            assertThat(name).isNotNull();
+            assertThat(id).isNotNull();
+            assertThat(parent).isNotNull();
+            assertThat(name.equals(id) && id.equals(parent)).isFalse();
+            assertThat(element.get("experimentAccessions")).isNotNull();
+        });
+    }
+
+    private void assertAllResultsParentIsGivenSpecies(String speciesName,
+                                                      ImmutableList<ImmutableMap<String, ?>> resultAsList) {
+        resultAsList.forEach(element -> {
+            var id = element.get("id").toString();
+            var parent = element.get("parent").toString();
+            assertThat(id.startsWith(speciesName)).isTrue();
+            if (!parent.isBlank()) {
+                assertThat(parent.startsWith(speciesName)).isTrue();
+            }
+        });
+    }
+
+    private List<Species> generateSpecies(int numberOfSpecies) {
+        return IntStream.rangeClosed(1, numberOfSpecies)
+                .mapToObj(i -> generateRandomSpecies())
+                .collect(toList());
+    }
+
+    private List<String> generateOrganism(int numberOfOrganism) {
+        return IntStream.rangeClosed(1, numberOfOrganism)
+                .mapToObj(i -> "organism_" + randomAlphabetic(10))
+                .collect(toList());
+    }
+
+    private List<String> generateCellTypes(int numberOfCellTypes) {
+        return IntStream.rangeClosed(1, numberOfCellTypes)
+                .mapToObj(i -> "cellType_" + randomAlphabetic(30))
+                .collect(toList());
+    }
+
+    private List<String> generateAccessions(int numberOfAccessions) {
+        return IntStream.rangeClosed(1, numberOfAccessions)
+                .mapToObj(i -> "acc_" + generateRandomExperimentAccession())
+                .collect(toList());
+    }
+
+    private ImmutableSet<ImmutablePair<ImmutableList<String>, String>> getSearchResultForASpecies(List<Species> species) {
+        var organismParts = generateOrganism(2);
+        var cellTypes = generateCellTypes(4);
+        var accessions = generateAccessions(2);
+
+        return // Species
+                ImmutableSet.of(
+                        ImmutablePair.of(
+                                ImmutableList.of(species.get(0).getName()),
+                                accessions.get(0)),
+                        ImmutablePair.of(
+                                ImmutableList.of(species.get(0).getName()),
+                                accessions.get(1)),
                         // Organism part 1
-                        ImmutableSet.of(ImmutablePair.of(
-                                ImmutableList.of(species1.getName(), species1OrganismPart1),
-                                species1OrganismPart1ExperimentAccession)),
+                        ImmutablePair.of(
+                                ImmutableList.of(species.get(0).getName(), organismParts.get(0)),
+                                accessions.get(0)),
                         // Organism part 2
-                        ImmutableSet.of(ImmutablePair.of(
-                                ImmutableList.of(species1.getName(), species1OrganismPart2),
-                                species1OrganismPart2ExperimentAccession)),
+                        ImmutablePair.of(
+                                ImmutableList.of(species.get(0).getName(), organismParts.get(1)),
+                                accessions.get(1)),
                         // Organism part 1, cell types
-                        ImmutableSet.of(ImmutablePair.of(
-                                ImmutableList.of(
-                                        species1.getName(), species1OrganismPart1, species1OrganismPart1CellType1),
-                                species1OrganismPart1ExperimentAccession)),
-                        ImmutableSet.of(ImmutablePair.of(
-                                ImmutableList.of(
-                                        species1.getName(), species1OrganismPart1, species1OrganismPart1CellType2),
-                                species1OrganismPart1ExperimentAccession)),
-                        ImmutableSet.of(ImmutablePair.of(
-                                ImmutableList.of(
-                                        species1.getName(), species1OrganismPart1, species1OrganismPart1CellType3),
-                                species1OrganismPart1ExperimentAccession)),
+                        ImmutablePair.of(
+                                ImmutableList.of(species.get(0).getName(), organismParts.get(0), cellTypes.get(0)),
+                                accessions.get(0)),
+                        ImmutablePair.of(
+                                ImmutableList.of(species.get(0).getName(), organismParts.get(0), cellTypes.get(1)),
+                                accessions.get(0)),
+                        ImmutablePair.of(
+                                ImmutableList.of(species.get(0).getName(), organismParts.get(0), cellTypes.get(2)),
+                                accessions.get(0)),
                         // Organism part 2, cell types
-                        ImmutableSet.of(ImmutablePair.of(
-                                ImmutableList.of(
-                                        species1.getName(), species1OrganismPart2, species1OrganismPart2CellType1),
-                                species1OrganismPart2ExperimentAccession)));
-    }
-
-    @Test
-    void wheelResponseShouldContainIdAndParenAttributesAreNonEmptyValues() {
-        var result = subject.getCellTypeWheelSunburst(metadataSearchTerm, cellTypeWheelServiceMock
-                .search(metadataSearchTerm, species1.getName()));
-        assertFalse(result.isEmpty());
-        assertNotEquals("", result.asList().get(1).get("id"));
-        assertNotEquals("", result.asList().get(1).get("parent"));
-    }
-
-    @Test
-    void wheelRingsResultShouldContainsIdAndParentValuesAreDifferentAfterAppendingUUIDToRight() {
-        var species = generateRandomSpecies();
-        var experimentAccession1 = RandomDataTestUtils.generateRandomExperimentAccession();
-        var experimentAccession2 = RandomDataTestUtils.generateRandomExperimentAccession();
-        var experimentAccession3 = RandomDataTestUtils.generateRandomExperimentAccession();
-
-        when(cellTypeWheelServiceMock.search(metadataSearchTerm, species1.getName()))
-                .thenReturn(
-                        ImmutableSet.of(
-                                ImmutablePair.of(
-                                        ImmutableList.of(species.getName()), (experimentAccession1))),
-                        ImmutableSet.of(
-                                ImmutablePair.of(
-                                        ImmutableList.of(species.getName()), (experimentAccession2))),
-                        ImmutableSet.of(
-                                ImmutablePair.of(
-                                        ImmutableList.of(species.getName()), (experimentAccession3))));
-
-        var result = subject.getCellTypeWheelSunburst(metadataSearchTerm,
-                cellTypeWheelServiceMock.search(metadataSearchTerm, species1.getName()));
-
-        assertThat(result).hasSize(2);
-        assertNotEquals(result.asList().get(0).get("id"), (result.asList().get(0).get("parent")));
-        assertNotEquals(result.asList().get(1).get("id"), (result.asList().get(1).get("parent")));
+                        ImmutablePair.of(
+                                ImmutableList.of(species.get(0).getName(), organismParts.get(1), cellTypes.get(3)),
+                                accessions.get(1))
+                );
     }
 }

--- a/app/src/test/java/uk/ac/ebi/atlas/search/metadata/JsonCellTypeWheelControllerWIT.java
+++ b/app/src/test/java/uk/ac/ebi/atlas/search/metadata/JsonCellTypeWheelControllerWIT.java
@@ -14,10 +14,8 @@ import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.util.UriComponentsBuilder;
 import uk.ac.ebi.atlas.configuration.TestConfig;
 
-import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isA;
 import static org.hamcrest.Matchers.lessThan;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -89,8 +87,6 @@ class JsonCellTypeWheelControllerWIT {
         this.mockMvc.perform(get(uri))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8))
-                .andExpect(jsonPath("$", hasSize(1)))
-                .andExpect(jsonPath("$[0].experimentAccessions", is(empty())));
-
+                .andExpect(jsonPath("$", hasSize(0)));
     }
 }


### PR DESCRIPTION
The search result processing for the cell type wheel was completely broken.
This change fixing the following issues:
- remove an element from the search result if the element's key equals with the search term. It happens when we search for a species.
- returns an empty `ImmutableSet` if the search result is empty. Before this change it returned only the search term and that was visualised in the cell type wheel. 
This change also completely replaces the wrongly written test case and adds more test cases to cover each cases.