### PR TITLE
[bugfix] Add species when redirect to metadata search

### DIFF
--- a/app/src/main/java/uk/ac/ebi/atlas/search/SearchController.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/search/SearchController.java
@@ -37,16 +37,27 @@ public class SearchController extends HtmlExceptionHandlingController {
                 .newInstance()
                 .path(SEARCH_ENDPOINT);
 
+        addCategoryToURL(queryObject, searchUrlBuilder);
+
+        addSpeciesToURL(species, searchUrlBuilder);
+
+        return "redirect:" + searchUrlBuilder.build().toUriString();
+    }
+
+    private void addCategoryToURL(JsonObject queryObject, UriComponentsBuilder searchUrlBuilder) {
         if (queryObject.get("category").getAsString().equals("metadata")) {
             searchUrlBuilder
                     .pathSegment("metadata", queryObject.get("term").getAsString());
         } else {
             searchUrlBuilder
-                    .queryParam(queryObject.get("category").getAsString(), queryObject.get("term").getAsString())
-                    .queryParam("species", species);
+                    .queryParam(queryObject.get("category").getAsString(), queryObject.get("term").getAsString());
         }
+    }
 
-        return "redirect:" + searchUrlBuilder.build().toUriString();
+    private void addSpeciesToURL(String species, UriComponentsBuilder searchUrlBuilder) {
+        if (!species.isBlank()) {
+            searchUrlBuilder.queryParam("species", species);
+        }
     }
 
     @RequestMapping(value = SEARCH_ENDPOINT, method = RequestMethod.GET, produces = "text/html;charset=UTF-8")

--- a/app/src/test/java/uk/ac/ebi/atlas/search/SearchControllerWIT.java
+++ b/app/src/test/java/uk/ac/ebi/atlas/search/SearchControllerWIT.java
@@ -100,6 +100,20 @@ class SearchControllerWIT {
     }
 
     @Test
+    void metadataAndSpeciesParamsAreParsedAndAddedToGetRequest() throws Exception {
+        var term = randomAlphanumeric(10);
+        var category = "metadata";
+        var species = randomAlphanumeric(4) + " " + randomAlphanumeric(6);
+
+        this.mockMvc.perform(
+                        post("/search")
+                                .param("geneQuery", GSON.toJson(ImmutableMap.of("term", term, "category", category)))
+                                .param("species", species))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/search/" + category + "/" + term + "?species=" + species));
+    }
+
+    @Test
     void otherRequestParamsAreIgnored() throws Exception {
         var term = randomAlphanumeric(10);
         var category = randomAlphanumeric(10);


### PR DESCRIPTION
In our basic `/search` endpoint when we redirected the search we did not added species as a request parameter if the search category was `metadata`. In any other search category the species was added as a request parameter.