### PR TITLE
[Chore] Set species dropdown default value to Any

### DIFF
--- a/app/src/main/webapp/WEB-INF/jsp/tiles/views/home/search.jsp
+++ b/app/src/main/webapp/WEB-INF/jsp/tiles/views/home/search.jsp
@@ -15,11 +15,11 @@
 
 <script defer src="${pageContext.request.contextPath}/resources/js-bundles/geneSearchForm.bundle.js"></script>
 <script>
-    document.addEventListener("DOMContentLoaded", function (event) {
+    document.addEventListener("DOMContentLoaded", function () {
         geneSearchForm.render({
             host: '${pageContext.request.contextPath}/',
             resource: 'json/suggestions/species',
-            defaultSpecies: `Homo sapiens`,
+            defaultSpecies: `Any`,
             wrapperClassName: 'row expanded',
             actionEndpoint: 'search',
 


### PR DESCRIPTION
On the homepage of the Single Cell Expression Atlas the default value of the `Species` dropdown in the search panel was `Homo sapiens`. The team wanted to change it to `Any`.
This tiny change implementing the above request. 