### PR TITLE
[bugfix] Render big dataset with Highcharts in the Single Cell web app

### DIFF
--- a/app/src/main/javascript/bundles/cell-type-wheel-heatmap/package.json
+++ b/app/src/main/javascript/bundles/cell-type-wheel-heatmap/package.json
@@ -13,7 +13,7 @@
   ],
   "license": "Apache-2.0",
   "dependencies": {
-    "@ebi-gene-expression-group/scxa-cell-type-wheel-heatmap": "^1.4.0",
+    "@ebi-gene-expression-group/scxa-cell-type-wheel-heatmap": "^1.4.3",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
   },

--- a/app/src/main/javascript/bundles/gene-search/package.json
+++ b/app/src/main/javascript/bundles/gene-search/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@ebi-gene-expression-group/atlas-react-fetch-loader": "^3.9.0",
     "@ebi-gene-expression-group/react-ebi-species": "^2.6.2",
-    "@ebi-gene-expression-group/scxa-faceted-search-results": "^4.1.2",
+    "@ebi-gene-expression-group/scxa-faceted-search-results": "^4.1.4",
     "@ebi-gene-expression-group/scxa-gene-search-form": "^2.0.2",
     "format-number": "^3.0.0",
     "prop-types": "^15.7.2",


### PR DESCRIPTION
To be able to render big datasets on the cell type wheel we updated the `scxa-cell-type-wheel-heatmap` component in the `atlas-component` repo and we are using that latest/updated version of that component in this web application.
I aso updated the `faceted search result` component to the latest version. 