### PR TITLE
Filter species metadata cell type wheel search on ogranism field

### DIFF
--- a/app/src/main/java/uk/ac/ebi/atlas/search/metadata/CellTypeWheelDao.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/search/metadata/CellTypeWheelDao.java
@@ -116,8 +116,12 @@ public class CellTypeWheelDao {
                         .setRows(0);    // We only want the facets, we don’t care about the docs;
 
         // If there’s a species or the search term is a species add it as an additional filter
-        if (isNotBlank(species) || isSpeciesSearch) {
+        if (isNotBlank(species)) {
             queryBuilder.addFilterFieldByTerm(CTW_ORGANISM, species);
+        }
+
+        if (isSpeciesSearch) {
+            queryBuilder.addFilterFieldByTerm(CTW_ORGANISM, searchTerm);
         }
 
         // Add the facet to the query

--- a/app/src/main/java/uk/ac/ebi/atlas/search/metadata/CellTypeWheelDao.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/search/metadata/CellTypeWheelDao.java
@@ -81,7 +81,7 @@ public class CellTypeWheelDao {
         singleCellAnalyticsCollectionProxy = proxyFactory.create(SingleCellAnalyticsCollectionProxy.class);
     }
 
-    public ImmutableList<ImmutableList<String>> facetSearchCtwFields(String searchTerm, String species) {
+    public ImmutableList<ImmutableList<String>> facetSearchCtwFields(String searchTerm, String species, boolean isSpeciesSearch) {
         // Build the facet in the query above:
         // "facet": {
         //   ...
@@ -115,8 +115,8 @@ public class CellTypeWheelDao {
                         .addNegativeFilterFieldByTerm(CTW_CELL_TYPE, ImmutableList.of(NOT_APPLICABLE_TERM))
                         .setRows(0);    // We only want the facets, we don’t care about the docs;
 
-        // If there’s a species add it as an additional filter
-        if (isNotBlank(species)) {
+        // If there’s a species or the search term is a species add it as an additional filter
+        if (isNotBlank(species) || isSpeciesSearch) {
             queryBuilder.addFilterFieldByTerm(CTW_ORGANISM, species);
         }
 

--- a/app/src/main/java/uk/ac/ebi/atlas/search/metadata/CellTypeWheelDao.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/search/metadata/CellTypeWheelDao.java
@@ -100,6 +100,9 @@ public class CellTypeWheelDao {
     public ImmutableList<ImmutableList<String>> speciesSearchCtwFields(String searchTerm, String species) {
         var queryBuilder = buildSolrQueryForCellTypeWheel(searchTerm);
 
+        if (isNotBlank(species)) {
+            queryBuilder.addFilterFieldByTerm(CTW_ORGANISM, species);
+        }
         // If the search term is a species add it as an additional filter
         queryBuilder.addFilterFieldByTerm(CTW_ORGANISM, searchTerm);
 

--- a/app/src/main/java/uk/ac/ebi/atlas/search/metadata/CellTypeWheelService.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/search/metadata/CellTypeWheelService.java
@@ -27,13 +27,20 @@ public class CellTypeWheelService {
         ImmutableList<String> allSpeciesNames = featuredSpeciesService.getSpeciesNamesSortedByExperimentCount();
         var isSpeciesSearch = allSpeciesNames.contains(StringUtils.capitalize(searchTerm));
 
-        return cellTypeWheelDao.facetSearchCtwFields(searchTerm, species, isSpeciesSearch)
+        return isSpeciesSearch ? cellTypeWheelDao.facetSearchCtwFields(searchTerm, species)
                 .stream()
                 // This will effectively “explode” tuples and aggregate experiment accessions (the last element in the
                 // tuple) to the organisms, organism parts and cell types
                 .map(this::addTailToEveryHeadSublist)
                 .flatMap(ImmutableList::stream)
-                .collect(toImmutableSet());
+                .collect(toImmutableSet()) :
+                cellTypeWheelDao.speciesSearchCtwFields(searchTerm, species)
+                        .stream()
+                        // This will effectively “explode” tuples and aggregate experiment accessions (the last element in the
+                        // tuple) to the organisms, organism parts and cell types
+                        .map(this::addTailToEveryHeadSublist)
+                        .flatMap(ImmutableList::stream)
+                        .collect(toImmutableSet());
     }
 
     // Transform a list [e_1, e_2, e_3, ..., e_n] into:

--- a/app/src/main/java/uk/ac/ebi/atlas/search/metadata/CellTypeWheelService.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/search/metadata/CellTypeWheelService.java
@@ -27,14 +27,14 @@ public class CellTypeWheelService {
         ImmutableList<String> allSpeciesNames = featuredSpeciesService.getSpeciesNamesSortedByExperimentCount();
         var isSpeciesSearch = allSpeciesNames.contains(StringUtils.capitalize(searchTerm));
 
-        return isSpeciesSearch ? cellTypeWheelDao.facetSearchCtwFields(searchTerm, species)
+        return isSpeciesSearch ? cellTypeWheelDao.speciesSearchCtwFields(searchTerm, species)
                 .stream()
                 // This will effectively “explode” tuples and aggregate experiment accessions (the last element in the
                 // tuple) to the organisms, organism parts and cell types
                 .map(this::addTailToEveryHeadSublist)
                 .flatMap(ImmutableList::stream)
                 .collect(toImmutableSet()) :
-                cellTypeWheelDao.speciesSearchCtwFields(searchTerm, species)
+                cellTypeWheelDao.facetSearchCtwFields(searchTerm, species)
                         .stream()
                         // This will effectively “explode” tuples and aggregate experiment accessions (the last element in the
                         // tuple) to the organisms, organism parts and cell types

--- a/app/src/main/java/uk/ac/ebi/atlas/search/metadata/CellTypeWheelService.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/search/metadata/CellTypeWheelService.java
@@ -5,6 +5,7 @@ import com.google.common.collect.ImmutableSet;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.springframework.stereotype.Service;
 import uk.ac.ebi.atlas.search.FeaturedSpeciesService;
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.stream.IntStream;
 

--- a/app/src/main/java/uk/ac/ebi/atlas/search/metadata/CellTypeWheelService.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/search/metadata/CellTypeWheelService.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.springframework.stereotype.Service;
+import uk.ac.ebi.atlas.search.FeaturedSpeciesService;
 
 import java.util.stream.IntStream;
 
@@ -13,13 +14,19 @@ import static com.google.common.collect.ImmutableSet.toImmutableSet;
 @Service
 public class CellTypeWheelService {
     private final CellTypeWheelDao cellTypeWheelDao;
+    private final FeaturedSpeciesService featuredSpeciesService;
 
-    public CellTypeWheelService(CellTypeWheelDao cellTypeWheelDao) {
+    public CellTypeWheelService(CellTypeWheelDao cellTypeWheelDao,
+                                FeaturedSpeciesService featuredSpeciesService) {
         this.cellTypeWheelDao = cellTypeWheelDao;
+        this.featuredSpeciesService = featuredSpeciesService;
     }
 
     public ImmutableSet<ImmutablePair<ImmutableList<String>, String>> search(String searchTerm, String species) {
-        return cellTypeWheelDao.facetSearchCtwFields(searchTerm, species)
+        ImmutableList<String> allSpeciesNames = featuredSpeciesService.getSpeciesNamesSortedByExperimentCount();
+        var isSpeciesSearch = allSpeciesNames.contains(searchTerm);
+
+        return cellTypeWheelDao.facetSearchCtwFields(searchTerm, species, isSpeciesSearch)
                 .stream()
                 // This will effectively “explode” tuples and aggregate experiment accessions (the last element in the
                 // tuple) to the organisms, organism parts and cell types

--- a/app/src/main/java/uk/ac/ebi/atlas/search/metadata/CellTypeWheelService.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/search/metadata/CellTypeWheelService.java
@@ -24,7 +24,7 @@ public class CellTypeWheelService {
 
     public ImmutableSet<ImmutablePair<ImmutableList<String>, String>> search(String searchTerm, String species) {
         ImmutableList<String> allSpeciesNames = featuredSpeciesService.getSpeciesNamesSortedByExperimentCount();
-        var isSpeciesSearch = allSpeciesNames.contains(searchTerm);
+        var isSpeciesSearch = allSpeciesNames.contains(StringUtils.capitalize(searchTerm));
 
         return cellTypeWheelDao.facetSearchCtwFields(searchTerm, species, isSpeciesSearch)
                 .stream()

--- a/app/src/test/java/uk/ac/ebi/atlas/search/metadata/CellTypeWheelDaoIT.java
+++ b/app/src/test/java/uk/ac/ebi/atlas/search/metadata/CellTypeWheelDaoIT.java
@@ -63,6 +63,18 @@ class CellTypeWheelDaoIT {
     }
 
     @Test
+    void isSpeciesSearchOnlyHasOneSpecies() {
+        var species = MULTIPLE_SPECIES.get(RNG.nextInt(MULTIPLE_SPECIES.size()));
+        var resultsWithSpeciesSearch =
+                subject.facetSearchCtwFields(species, generateBlankString(), true);
+        assertThat(
+                resultsWithSpeciesSearch.stream()
+                        .map(result -> result.get(0))
+                        .distinct())
+                .containsExactly(species);
+    }
+
+    @Test
     void unknownTermReturnsEmpty() {
         assertThat(subject.facetSearchCtwFields("foobar", generateBlankString(), false)).isEmpty();
     }

--- a/app/src/test/java/uk/ac/ebi/atlas/search/metadata/CellTypeWheelDaoIT.java
+++ b/app/src/test/java/uk/ac/ebi/atlas/search/metadata/CellTypeWheelDaoIT.java
@@ -31,7 +31,7 @@ class CellTypeWheelDaoIT {
 
     @Test
     void knownTermReturnsResultsWithoutNotApplicable() {
-        var results = subject.facetSearchCtwFields(MULTIPLE_SPECIES_METADATA_TERM, null, false);
+        var results = subject.facetSearchCtwFields(MULTIPLE_SPECIES_METADATA_TERM, null);
 
         assertThat(
                 results.stream()
@@ -45,9 +45,9 @@ class CellTypeWheelDaoIT {
     void canFilterBySpecies() {
         var speciesFilter = MULTIPLE_SPECIES.get(RNG.nextInt(MULTIPLE_SPECIES.size()));
         var resultsWithoutSpeciesFiltering =
-                subject.facetSearchCtwFields(MULTIPLE_SPECIES_METADATA_TERM, generateBlankString(), false);
+                subject.facetSearchCtwFields(MULTIPLE_SPECIES_METADATA_TERM, generateBlankString());
         var resultsWithSpeciesFitlering =
-                subject.facetSearchCtwFields(MULTIPLE_SPECIES_METADATA_TERM, speciesFilter, false);
+                subject.facetSearchCtwFields(MULTIPLE_SPECIES_METADATA_TERM, speciesFilter);
 
         assertThat(
                 resultsWithoutSpeciesFiltering.stream()
@@ -66,7 +66,7 @@ class CellTypeWheelDaoIT {
     void isSpeciesSearchOnlyHasOneSpecies() {
         var species = MULTIPLE_SPECIES.get(RNG.nextInt(MULTIPLE_SPECIES.size()));
         var resultsWithSpeciesSearch =
-                subject.facetSearchCtwFields(species, generateBlankString(), true);
+                subject.speciesSearchCtwFields(species, generateBlankString());
         assertThat(
                 resultsWithSpeciesSearch.stream()
                         .map(result -> result.get(0))
@@ -76,7 +76,7 @@ class CellTypeWheelDaoIT {
 
     @Test
     void unknownTermReturnsEmpty() {
-        assertThat(subject.facetSearchCtwFields("foobar", generateBlankString(), false)).isEmpty();
+        assertThat(subject.facetSearchCtwFields("foobar", generateBlankString())).isEmpty();
     }
 
 }

--- a/app/src/test/java/uk/ac/ebi/atlas/search/metadata/CellTypeWheelDaoIT.java
+++ b/app/src/test/java/uk/ac/ebi/atlas/search/metadata/CellTypeWheelDaoIT.java
@@ -31,7 +31,7 @@ class CellTypeWheelDaoIT {
 
     @Test
     void knownTermReturnsResultsWithoutNotApplicable() {
-        var results = subject.facetSearchCtwFields(MULTIPLE_SPECIES_METADATA_TERM, null);
+        var results = subject.facetSearchCtwFields(MULTIPLE_SPECIES_METADATA_TERM, null, false);
 
         assertThat(
                 results.stream()
@@ -45,9 +45,9 @@ class CellTypeWheelDaoIT {
     void canFilterBySpecies() {
         var speciesFilter = MULTIPLE_SPECIES.get(RNG.nextInt(MULTIPLE_SPECIES.size()));
         var resultsWithoutSpeciesFiltering =
-                subject.facetSearchCtwFields(MULTIPLE_SPECIES_METADATA_TERM, generateBlankString());
+                subject.facetSearchCtwFields(MULTIPLE_SPECIES_METADATA_TERM, generateBlankString(), false);
         var resultsWithSpeciesFitlering =
-                subject.facetSearchCtwFields(MULTIPLE_SPECIES_METADATA_TERM, speciesFilter);
+                subject.facetSearchCtwFields(MULTIPLE_SPECIES_METADATA_TERM, speciesFilter, false);
 
         assertThat(
                 resultsWithoutSpeciesFiltering.stream()
@@ -64,7 +64,7 @@ class CellTypeWheelDaoIT {
 
     @Test
     void unknownTermReturnsEmpty() {
-        assertThat(subject.facetSearchCtwFields("foobar", generateBlankString())).isEmpty();
+        assertThat(subject.facetSearchCtwFields("foobar", generateBlankString(), false)).isEmpty();
     }
 
 }

--- a/app/src/test/java/uk/ac/ebi/atlas/search/metadata/CellTypeWheelServiceTest.java
+++ b/app/src/test/java/uk/ac/ebi/atlas/search/metadata/CellTypeWheelServiceTest.java
@@ -27,13 +27,13 @@ class CellTypeWheelServiceTest {
     @BeforeEach
     void setUp() {
         subject = new CellTypeWheelService(cellTypeWheelDaoMock, featuredSpeciesServiceMock);
+        when(featuredSpeciesServiceMock.getSpeciesNamesSortedByExperimentCount()).thenReturn(ImmutableList.of());
     }
 
     @Test
     void emptyFacetTermsProducesAnEmptyWheel() {
         var metadataSearchTerm =  randomAlphabetic(20);
         var species = generateRandomSpecies();
-
         when(cellTypeWheelDaoMock.facetSearchCtwFields(metadataSearchTerm, null, false))
                 .thenReturn(ImmutableList.of());
         when(cellTypeWheelDaoMock.facetSearchCtwFields(metadataSearchTerm, species.getName(), false))

--- a/app/src/test/java/uk/ac/ebi/atlas/search/metadata/CellTypeWheelServiceTest.java
+++ b/app/src/test/java/uk/ac/ebi/atlas/search/metadata/CellTypeWheelServiceTest.java
@@ -39,8 +39,19 @@ class CellTypeWheelServiceTest {
         when(cellTypeWheelDaoMock.facetSearchCtwFields(metadataSearchTerm, species.getName(), false))
                 .thenReturn(ImmutableList.of());
 
+
         assertThat(subject.search(metadataSearchTerm, null)).isEmpty();
         assertThat(subject.search(metadataSearchTerm, species.getName())).isEmpty();
+    }
+
+    @Test
+    void speciesTermSearchProducesAnEmptyWheel() {
+        var species = generateRandomSpecies();
+        when(featuredSpeciesServiceMock.getSpeciesNamesSortedByExperimentCount()).thenReturn(ImmutableList.of(species.getName()));
+        when(cellTypeWheelDaoMock.facetSearchCtwFields(species.getName(), null, true))
+                .thenReturn(ImmutableList.of());
+
+        assertThat(subject.search(species.getName(), null)).isEmpty();
     }
 
     @Test

--- a/app/src/test/java/uk/ac/ebi/atlas/search/metadata/CellTypeWheelServiceTest.java
+++ b/app/src/test/java/uk/ac/ebi/atlas/search/metadata/CellTypeWheelServiceTest.java
@@ -36,7 +36,7 @@ class CellTypeWheelServiceTest {
         var species = generateRandomSpecies();
         when(cellTypeWheelDaoMock.facetSearchCtwFields(metadataSearchTerm, null))
                 .thenReturn(ImmutableList.of());
-        when(cellTypeWheelDaoMock.facetSearchCtwFields(metadataSearchTerm, species.getName()))
+        when(cellTypeWheelDaoMock.speciesSearchCtwFields(metadataSearchTerm, species.getName()))
                 .thenReturn(ImmutableList.of());
 
 

--- a/app/src/test/java/uk/ac/ebi/atlas/search/metadata/CellTypeWheelServiceTest.java
+++ b/app/src/test/java/uk/ac/ebi/atlas/search/metadata/CellTypeWheelServiceTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.ac.ebi.atlas.search.FeaturedSpeciesService;
 
 import static org.apache.commons.lang3.RandomStringUtils.randomAlphabetic;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -18,12 +19,14 @@ import static uk.ac.ebi.atlas.testutils.RandomDataTestUtils.generateRandomSpecie
 class CellTypeWheelServiceTest {
     @Mock
     private CellTypeWheelDao cellTypeWheelDaoMock;
+    @Mock
+    private FeaturedSpeciesService featuredSpeciesServiceMock;
 
     private CellTypeWheelService subject;
 
     @BeforeEach
     void setUp() {
-        subject = new CellTypeWheelService(cellTypeWheelDaoMock);
+        subject = new CellTypeWheelService(cellTypeWheelDaoMock, featuredSpeciesServiceMock);
     }
 
     @Test
@@ -31,9 +34,9 @@ class CellTypeWheelServiceTest {
         var metadataSearchTerm =  randomAlphabetic(20);
         var species = generateRandomSpecies();
 
-        when(cellTypeWheelDaoMock.facetSearchCtwFields(metadataSearchTerm, null))
+        when(cellTypeWheelDaoMock.facetSearchCtwFields(metadataSearchTerm, null, false))
                 .thenReturn(ImmutableList.of());
-        when(cellTypeWheelDaoMock.facetSearchCtwFields(metadataSearchTerm, species.getName()))
+        when(cellTypeWheelDaoMock.facetSearchCtwFields(metadataSearchTerm, species.getName(), false))
                 .thenReturn(ImmutableList.of());
 
         assertThat(subject.search(metadataSearchTerm, null)).isEmpty();
@@ -156,7 +159,7 @@ class CellTypeWheelServiceTest {
                         )
                 );
 
-        when(cellTypeWheelDaoMock.facetSearchCtwFields(metadataSearchTerm, null))
+        when(cellTypeWheelDaoMock.facetSearchCtwFields(metadataSearchTerm, null, false))
                 .thenReturn(twoSpeciesCellTypesWheel);
 
         assertThat(subject.search(metadataSearchTerm, null))
@@ -284,7 +287,7 @@ class CellTypeWheelServiceTest {
                                 species1OrganismPart2ExperimentAccession
                         ));
 
-        when(cellTypeWheelDaoMock.facetSearchCtwFields(metadataSearchTerm, species1.getName()))
+        when(cellTypeWheelDaoMock.facetSearchCtwFields(metadataSearchTerm, species1.getName(), false))
                 .thenReturn(oneSpeciesCellTypesWheel);
 
         assertThat(subject.search(metadataSearchTerm, species1.getName()))

--- a/app/src/test/java/uk/ac/ebi/atlas/search/metadata/CellTypeWheelServiceTest.java
+++ b/app/src/test/java/uk/ac/ebi/atlas/search/metadata/CellTypeWheelServiceTest.java
@@ -36,7 +36,7 @@ class CellTypeWheelServiceTest {
         var species = generateRandomSpecies();
         when(cellTypeWheelDaoMock.facetSearchCtwFields(metadataSearchTerm, null))
                 .thenReturn(ImmutableList.of());
-        when(cellTypeWheelDaoMock.speciesSearchCtwFields(metadataSearchTerm, species.getName()))
+        when(cellTypeWheelDaoMock.facetSearchCtwFields(metadataSearchTerm, species.getName()))
                 .thenReturn(ImmutableList.of());
 
 

--- a/app/src/test/java/uk/ac/ebi/atlas/search/metadata/CellTypeWheelServiceTest.java
+++ b/app/src/test/java/uk/ac/ebi/atlas/search/metadata/CellTypeWheelServiceTest.java
@@ -34,9 +34,9 @@ class CellTypeWheelServiceTest {
     void emptyFacetTermsProducesAnEmptyWheel() {
         var metadataSearchTerm =  randomAlphabetic(20);
         var species = generateRandomSpecies();
-        when(cellTypeWheelDaoMock.facetSearchCtwFields(metadataSearchTerm, null, false))
+        when(cellTypeWheelDaoMock.facetSearchCtwFields(metadataSearchTerm, null))
                 .thenReturn(ImmutableList.of());
-        when(cellTypeWheelDaoMock.facetSearchCtwFields(metadataSearchTerm, species.getName(), false))
+        when(cellTypeWheelDaoMock.facetSearchCtwFields(metadataSearchTerm, species.getName()))
                 .thenReturn(ImmutableList.of());
 
 
@@ -48,7 +48,7 @@ class CellTypeWheelServiceTest {
     void speciesTermSearchProducesAnEmptyWheel() {
         var species = generateRandomSpecies();
         when(featuredSpeciesServiceMock.getSpeciesNamesSortedByExperimentCount()).thenReturn(ImmutableList.of(species.getName()));
-        when(cellTypeWheelDaoMock.facetSearchCtwFields(species.getName(), null, true))
+        when(cellTypeWheelDaoMock.speciesSearchCtwFields(species.getName(), null))
                 .thenReturn(ImmutableList.of());
 
         assertThat(subject.search(species.getName(), null)).isEmpty();
@@ -170,7 +170,7 @@ class CellTypeWheelServiceTest {
                         )
                 );
 
-        when(cellTypeWheelDaoMock.facetSearchCtwFields(metadataSearchTerm, null, false))
+        when(cellTypeWheelDaoMock.facetSearchCtwFields(metadataSearchTerm, null))
                 .thenReturn(twoSpeciesCellTypesWheel);
 
         assertThat(subject.search(metadataSearchTerm, null))
@@ -298,7 +298,7 @@ class CellTypeWheelServiceTest {
                                 species1OrganismPart2ExperimentAccession
                         ));
 
-        when(cellTypeWheelDaoMock.facetSearchCtwFields(metadataSearchTerm, species1.getName(), false))
+        when(cellTypeWheelDaoMock.facetSearchCtwFields(metadataSearchTerm, species1.getName()))
                 .thenReturn(oneSpeciesCellTypesWheel);
 
         assertThat(subject.search(metadataSearchTerm, species1.getName()))


### PR DESCRIPTION
In the cell type wheel json response with `species` search term, for example, `Mus musculus` or `Homo sapiens`, due to the solr contains some cross-species ontology data, the results have other species. To resolve this problem, we need to create a filter on searching if the search term is a species.

Rather than passing a request parameter like, I think it's better to check if it's a species search in the back-end, as we don't have to call the `allSpecies` endpoints from front-end.