### PR TITLE
[bugfix] Change initial value for 'Species' from 'Any' to an empty value ('')

### DIFF
--- a/app/src/main/webapp/WEB-INF/jsp/tiles/views/home/search.jsp
+++ b/app/src/main/webapp/WEB-INF/jsp/tiles/views/home/search.jsp
@@ -19,7 +19,7 @@
         geneSearchForm.render({
             host: '${pageContext.request.contextPath}/',
             resource: 'json/suggestions/species',
-            defaultSpecies: `Any`,
+            defaultSpecies: ``,
             wrapperClassName: 'row expanded',
             actionEndpoint: 'search',
 


### PR DESCRIPTION
In the Single Cell Expression Atlas the gene search on the homepage was using `Any` as a value for the request parameter for species when we have not changed its value (its default value is `Any`). 
In case of the species dropdown set to Any, the request parameter should contains all the species's value.
After went through all the UI logic the fix was easy. I just have to set the initial value for `Species` to an empty value ('') and the UI logic deals with it and set its label to `Any`. When we send a query to the server the UI logic set the species value to 'all species' when the value is empty.