### PR TITLE
Bugfix search button not working after an initial metadata search

### DIFF
--- a/app/src/main/javascript/bundles/gene-search/html/index.html
+++ b/app/src/main/javascript/bundles/gene-search/html/index.html
@@ -27,7 +27,7 @@
 <!-- Set to http://localhost:8080/gxa/ or http://localhost:8080/gxa_sc/ -- Remember the trailing slash! -->
 <script>
   searchRouter.render({
-    atlasUrl: 'http://localhost:8080/gxa/sc/',
+    atlasUrl: 'https://wwwdev.ac.uk/gxa/sc/',
     basename: '',
   }, 'target');
 </script>

--- a/app/src/main/javascript/bundles/gene-search/src/GeneSearch.js
+++ b/app/src/main/javascript/bundles/gene-search/src/GeneSearch.js
@@ -16,12 +16,21 @@ function GeneSearch ({atlasUrl, history}) {
   const updateUrl = (event, query, species) => {
     event.preventDefault()
     history.push(
+    query.category === `metadata` ?
+      URI(`/search/metadata${query.term}`)
+        .query({
+            species: species
+            })
+        .toString() :
       URI(`/search`)
         .query({
           [query.category]: query.term,
           species: species
         })
-        .toString())
+        .toString()
+    )
+    query.category === `metadata` && history.go(0)
+
   }
 
   const requestParams = URI(location.search).query(true)

--- a/app/src/main/javascript/bundles/gene-search/src/GeneSearch.js
+++ b/app/src/main/javascript/bundles/gene-search/src/GeneSearch.js
@@ -17,7 +17,7 @@ function GeneSearch ({atlasUrl, history}) {
     event.preventDefault()
     history.push(
     query.category === `metadata` ?
-      URI(`/search/metadata${query.term}`)
+      URI(`/search/metadata/${query.term}`)
         .query({
             species: species
             })


### PR DESCRIPTION
The bug is when we search a gene and we will land in gene search result page, the endpoint is different with the metadata search, so the metadata search will not be triggered. The solution we discussed is to correct the router/url for metadata search.