### PR TITLE
Add external data hyperlink to help page

### DIFF
--- a/app/src/main/javascript/bundles/experiment-table/package.json
+++ b/app/src/main/javascript/bundles/experiment-table/package.json
@@ -11,7 +11,7 @@
   ],
   "license": "Apache-2.0",
   "dependencies": {
-    "@ebi-gene-expression-group/atlas-experiment-table": "^3.2.10",
+    "@ebi-gene-expression-group/atlas-experiment-table": "^3.2.11",
     "@ebi-gene-expression-group/atlas-react-fetch-loader": "^3.9.0",
     "react": "^16.13.1",
     "react-dom": "^16.13.1"

--- a/app/src/main/javascript/bundles/gene-search/src/ExperimentCard.js
+++ b/app/src/main/javascript/bundles/gene-search/src/ExperimentCard.js
@@ -54,7 +54,7 @@ class ExperimentCard extends React.Component {
            {experimentDescription}
             <SmallIconDiv>
               {showIcon &&
-                <a href={`${url}/help.html?section=external-data`}>
+                <a href={`${window.location.host}/help.html?section=external-data`}>
                   <ExperimentIconDiv background={`indianred`} color={`white`} data-toggle={`tooltip`}
                                      data-placement={`bottom`} title={`Externally analysed data`}
                   >E</ExperimentIconDiv>

--- a/app/src/main/javascript/bundles/gene-search/src/ExperimentCard.js
+++ b/app/src/main/javascript/bundles/gene-search/src/ExperimentCard.js
@@ -54,7 +54,7 @@ class ExperimentCard extends React.Component {
            {experimentDescription}
             <SmallIconDiv>
               {showIcon &&
-                <a href={`${window.location.host}/help.html?section=external-data`}>
+                <a href={`${window.location.host}/gxa/sc/help.html?section=external-data`}>
                   <ExperimentIconDiv background={`indianred`} color={`white`} data-toggle={`tooltip`}
                                      data-placement={`bottom`} title={`Externally analysed data`}
                   >E</ExperimentIconDiv>

--- a/app/src/main/javascript/bundles/gene-search/src/ExperimentCard.js
+++ b/app/src/main/javascript/bundles/gene-search/src/ExperimentCard.js
@@ -53,8 +53,12 @@ class ExperimentCard extends React.Component {
        <TitleDiv>
            {experimentDescription}
             <SmallIconDiv>
-              {showIcon && <ExperimentIconDiv background={`indianred`} color={`white`} data-toggle={`tooltip`} data-placement={`bottom`}
-                                              title={`Externally analysed data`}>E</ExperimentIconDiv>}
+              {showIcon &&
+                <a href={`${url}/help.html?section=external-data`}>
+                  <ExperimentIconDiv background={`indianred`} color={`white`} data-toggle={`tooltip`}
+                                     data-placement={`bottom`} title={`Externally analysed data`}
+                  >E</ExperimentIconDiv>
+                </a>}
             </SmallIconDiv>
        </TitleDiv>
         <VariableDiv>

--- a/app/src/main/webapp/WEB-INF/jsp/tiles/local-masthead.jsp
+++ b/app/src/main/webapp/WEB-INF/jsp/tiles/local-masthead.jsp
@@ -40,7 +40,7 @@
                     <li id="local-nav-experiments"><a href="${pageContext.request.contextPath}/experiments"><i class="icon icon-functional padding-right-medium" data-icon="C"></i>Browse experiments</a></li>
                     <li id="local-nav-download"><a href="${pageContext.request.contextPath}/download"><i class="icon icon-common padding-right-medium" data-icon="="></i>Download</a></li>
                     <li id="local-nav-release-notes"><a href="${pageContext.request.contextPath}/release-notes.html"><i class="icon icon-generic padding-right-medium" data-icon=";"></i>Release notes</a></li>
-                    <li id="local-nav-help"><a href="${pageContext.request.contextPath}/help.html"><i class="icon icon-generic padding-right-medium" data-icon="?"></i>Help</a></li>
+                    <li id="local-nav-help"><a href="${pageContext.request.contextPath}/help.html?section=${section}"><i class="icon icon-generic padding-right-medium" data-icon="?"></i>Help</a></li>
                     <%--<li id="local-nav-about"><a href="../websites/patterns/"><i class="icon icon-common padding-right-medium" data-icon="&#x2139;"></i>About</a></li>--%>
                     <li id="local-nav-feedback"><a href="https://www.ebi.ac.uk/support/gxasc" target="_blank" data-icon="X"><i class="icon icon-generic padding-right-medium" data-icon="s"></i>Support</a></li>
                 </ul>

--- a/app/src/main/webapp/WEB-INF/jsp/tiles/views/experiment-page/experiment-description.jsp
+++ b/app/src/main/webapp/WEB-INF/jsp/tiles/views/experiment-page/experiment-description.jsp
@@ -100,10 +100,12 @@
             </c:if>
         </div>
         <c:if test="${fn:startsWith(experimentAccession, 'E-ANND-')}">
-            <div class="experiment-type-icon"
-                 title="Externally analysed data">
-                E
-            </div>
+            <a href="${pageContext.request.contextPath}/help.html?section=external-data">
+                <div class="experiment-type-icon"
+                     title="Externally analysed data">
+                    E
+                </div>
+            </a>
         </c:if>
     </div>
 </div>

--- a/app/src/main/webapp/resources/html/help.html
+++ b/app/src/main/webapp/resources/html/help.html
@@ -1,14 +1,30 @@
 <script defer src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.2/iframeResizer.min.js"></script>
 
 <div class="row column">
-  <iframe id="atlas-help-iframe" class="row" src="https://ebi-gene-expression-group.github.io/atlas-help-pages/help-page-scxa.html"
+  <iframe id="atlas-help-iframe" class="row" src=""
           style="width: 1px; min-width: 100%; border: none; display: block; overflow: hidden;" name="atlas_help">
   </iframe>
 </div>
 
 <script>
   document.addEventListener("DOMContentLoaded", function(event) {
+    // Get the section parameter from the URL
+    const urlParams = new URLSearchParams(window.location.search);
+    const section = urlParams.get('section');
+
+    // Build the iframe src URL with the section parameter
+    let iframeSrc = "https://ebi-gene-expression-group.github.io/atlas-help-pages/help-page-scxa.html";
+    if (section) {
+      iframeSrc += `#${section}`;
+    }
+
+    // Set the iframe src attribute
+    document.getElementById("atlas-help-iframe").src = iframeSrc;
+
+    // Mark the Help nav item as active
     document.getElementById("local-nav-help").className += ' active';
-    iFrameResize({inPageLinks:true}, '#atlas-help-iframe');
+
+    // Initialize iframe resizing
+    iFrameResize({inPageLinks: true}, '#atlas-help-iframe');
   });
 </script>


### PR DESCRIPTION
With hash syntax, I add a hyperlink for external data icon to a specific section in the help page. 

- [x] experiment page description
- [x] experiments table page icon (related PR: https://github.com/ebi-gene-expression-group/atlas-components/pull/169)
- [x] gene search result page icon