### PR TITLE
[Chore] Replace FlyBase gene search example to FBgn0003062

### DIFF
--- a/app/src/main/webapp/WEB-INF/jsp/tiles/views/home/search.jsp
+++ b/app/src/main/webapp/WEB-INF/jsp/tiles/views/home/search.jsp
@@ -48,8 +48,8 @@
                     url: '${pageContext.request.contextPath}/search?mgi_id=MGI:98354'
                 },
                 {
-                    text: 'FBgn0004647 (FlyBase ID)',
-                    url: '${pageContext.request.contextPath}/search?flybase_gene_id=FBgn0004647'
+                    text: 'FBgn0003062 (FlyBase ID)',
+                    url: '${pageContext.request.contextPath}/search?flybase_gene_id=FBgn0003062'
                 },
                 {
                     text: 'keratinocyte (cell type)',


### PR DESCRIPTION
The current gene search example for FlyBase: he current gene search example for FlyBase: [FBgn0004647 (FlyBase ID)](https://wwwdev.ebi.ac.uk/gxa/sc/search?flybase_gene_id=FBgn0004647) is not working, as it times out.
We are going to replace it with another one:[FBgn0003062 (FlyBase ID)](https://wwwdev.ebi.ac.uk/gxa/sc/search?flybase_gene_id=FBgn0003062) with this change.