### PR TITLE
v16.0.0

### DIFF
--- a/buildSrc/src/main/groovy/atlas-web-app.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/atlas-web-app.java-conventions.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = 'uk.ac.ebi.ge'
-version = '1.0.0'
+version = '16.0.0'
 
 sourceCompatibility = 11
 targetCompatibility = 11


### PR DESCRIPTION
Start using versions for the app (v16.0.0).
Only the version of the web app has changed.
We can get the version by using the `/json/build` endpoint.
