### PR TITLE
bugfix/update-cell-type-marker-genes-endpoint-to-accept-slash-in-the-celltype

### DIFF
--- a/app/src/main/java/uk/ac/ebi/atlas/search/metadata/JsonMultiexperimentCellTypeMarkerGenesController.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/search/metadata/JsonMultiexperimentCellTypeMarkerGenesController.java
@@ -1,6 +1,7 @@
 package uk.ac.ebi.atlas.search.metadata;
 
 import com.google.common.collect.ImmutableSet;
+import org.jetbrains.annotations.NotNull;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -30,7 +31,7 @@ public class JsonMultiexperimentCellTypeMarkerGenesController extends JsonExcept
     }
 
     @GetMapping(value = "/json/cell-type-marker-genes/{cellType}",
-                produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+            produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
     public String getCellTypeMarkerGenes(
             @PathVariable String cellType,
             @RequestParam(name = "experiment-accessions", required = false) Collection<String> experimentAccessions) {
@@ -38,9 +39,18 @@ public class JsonMultiexperimentCellTypeMarkerGenesController extends JsonExcept
                 highchartsHeatmapAdapter.getMarkerGeneHeatmapDataSortedLexicographically(
                         experimentAccessions == null ?
                                 multiexperimentCellTypeMarkerGenesService.getCellTypeMarkerGeneProfile(
-                                        new String(Base64.getDecoder().decode(cellType), StandardCharsets.UTF_8)):
+                                        getDecodedCellType(cellType)) :
                                 multiexperimentCellTypeMarkerGenesService.getCellTypeMarkerGeneProfile(
                                         ImmutableSet.copyOf(experimentAccessions),
-                                        new String(Base64.getDecoder().decode(cellType), StandardCharsets.UTF_8))));
+                                        getDecodedCellType(cellType))));
+    }
+
+    private static @NotNull String getDecodedCellType(@NotNull String cellType) {
+        if (cellType == null || cellType.trim().isEmpty()) {
+            throw new IllegalArgumentException("Input cellType cannot be null or empty");
+        }
+
+        byte[] decodedBytes = Base64.getDecoder().decode(cellType);
+        return new String(decodedBytes, StandardCharsets.UTF_8);
     }
 }

--- a/app/src/main/java/uk/ac/ebi/atlas/search/metadata/JsonMultiexperimentCellTypeMarkerGenesController.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/search/metadata/JsonMultiexperimentCellTypeMarkerGenesController.java
@@ -45,11 +45,10 @@ public class JsonMultiexperimentCellTypeMarkerGenesController extends JsonExcept
                                         getDecodedCellType(cellType))));
     }
 
-    private static @NotNull String getDecodedCellType(@NotNull String cellType) {
+    private static String getDecodedCellType(String cellType) {
         if (cellType == null || cellType.trim().isEmpty()) {
             throw new IllegalArgumentException("Input cellType cannot be null or empty");
         }
-
         return new String(Base64.getDecoder().decode(cellType), StandardCharsets.UTF_8);
     }
 }

--- a/app/src/main/java/uk/ac/ebi/atlas/search/metadata/JsonMultiexperimentCellTypeMarkerGenesController.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/search/metadata/JsonMultiexperimentCellTypeMarkerGenesController.java
@@ -50,7 +50,6 @@ public class JsonMultiexperimentCellTypeMarkerGenesController extends JsonExcept
             throw new IllegalArgumentException("Input cellType cannot be null or empty");
         }
 
-        byte[] decodedBytes = Base64.getDecoder().decode(cellType);
-        return new String(decodedBytes, StandardCharsets.UTF_8);
+        return new String(Base64.getDecoder().decode(cellType), StandardCharsets.UTF_8);
     }
 }

--- a/app/src/main/java/uk/ac/ebi/atlas/search/metadata/JsonMultiexperimentCellTypeMarkerGenesController.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/search/metadata/JsonMultiexperimentCellTypeMarkerGenesController.java
@@ -38,9 +38,9 @@ public class JsonMultiexperimentCellTypeMarkerGenesController extends JsonExcept
                 highchartsHeatmapAdapter.getMarkerGeneHeatmapDataSortedLexicographically(
                         experimentAccessions == null ?
                                 multiexperimentCellTypeMarkerGenesService.getCellTypeMarkerGeneProfile(
-                                        new String(Base64.getDecoder().decode(cellType), Charset.defaultCharset())):
+                                        new String(Base64.getDecoder().decode(cellType), StandardCharsets.UTF_8)):
                                 multiexperimentCellTypeMarkerGenesService.getCellTypeMarkerGeneProfile(
                                         ImmutableSet.copyOf(experimentAccessions),
-                                        new String(Base64.getDecoder().decode(cellType), Charset.defaultCharset()))));
+                                        new String(Base64.getDecoder().decode(cellType), StandardCharsets.UTF_8))));
     }
 }

--- a/app/src/main/java/uk/ac/ebi/atlas/search/metadata/JsonMultiexperimentCellTypeMarkerGenesController.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/search/metadata/JsonMultiexperimentCellTypeMarkerGenesController.java
@@ -10,7 +10,9 @@ import uk.ac.ebi.atlas.controllers.JsonExceptionHandlingController;
 import uk.ac.ebi.atlas.experimentpage.markergenes.HighchartsHeatmapAdapter;
 
 import java.net.URLDecoder;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.Collection;
 
 import static uk.ac.ebi.atlas.utils.GsonProvider.GSON;
@@ -36,9 +38,9 @@ public class JsonMultiexperimentCellTypeMarkerGenesController extends JsonExcept
                 highchartsHeatmapAdapter.getMarkerGeneHeatmapDataSortedLexicographically(
                         experimentAccessions == null ?
                                 multiexperimentCellTypeMarkerGenesService.getCellTypeMarkerGeneProfile(
-                                        URLDecoder.decode(cellType, StandardCharsets.UTF_8)) :
+                                        new String(Base64.getDecoder().decode(cellType), Charset.defaultCharset())):
                                 multiexperimentCellTypeMarkerGenesService.getCellTypeMarkerGeneProfile(
                                         ImmutableSet.copyOf(experimentAccessions),
-                                        URLDecoder.decode(cellType, StandardCharsets.UTF_8))));
+                                        new String(Base64.getDecoder().decode(cellType), Charset.defaultCharset()))));
     }
 }

--- a/app/src/main/javascript/bundles/cell-type-wheel-heatmap/package.json
+++ b/app/src/main/javascript/bundles/cell-type-wheel-heatmap/package.json
@@ -13,7 +13,7 @@
   ],
   "license": "Apache-2.0",
   "dependencies": {
-    "@ebi-gene-expression-group/scxa-cell-type-wheel-heatmap": "^1.4.12",
+    "@ebi-gene-expression-group/scxa-cell-type-wheel-heatmap": "^1.4.14",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
   },

--- a/app/src/test/java/uk/ac/ebi/atlas/search/metadata/JsonMultiexperimentCellTypeMarkerGenesControllerWIT.java
+++ b/app/src/test/java/uk/ac/ebi/atlas/search/metadata/JsonMultiexperimentCellTypeMarkerGenesControllerWIT.java
@@ -16,6 +16,7 @@ import uk.ac.ebi.atlas.configuration.TestConfig;
 
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
@@ -62,7 +63,7 @@ class JsonMultiexperimentCellTypeMarkerGenesControllerWIT {
 
     @Test
     void shouldReturnAValidJsonPayloadForAValidCellType() throws Exception {
-        this.mockMvc.perform(get("/json/cell-type-marker-genes/{cellType}", "cell cycle S phase")
+        this.mockMvc.perform(get("/json/cell-type-marker-genes/{cellType}", getEncodedCellType("cell cycle S phase"))
                         .param("experimentAccession", "E-ENAD-53"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8))
@@ -74,8 +75,7 @@ class JsonMultiexperimentCellTypeMarkerGenesControllerWIT {
 
     @Test
     void shouldReturnAValidJsonPayloadForACellTypeContainingAForwardSlash() throws Exception {
-        final String encodedCellType = URLEncoder.encode("cell cycle G2/M phase", StandardCharsets.UTF_8);
-        this.mockMvc.perform(get("/json/cell-type-marker-genes/{cellType}", encodedCellType)
+        this.mockMvc.perform(get("/json/cell-type-marker-genes/{cellType}", getEncodedCellType("cell cycle G2/M phase"))
                         .param("experimentAccession", "E-ENAD-53"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8))
@@ -87,10 +87,16 @@ class JsonMultiexperimentCellTypeMarkerGenesControllerWIT {
 
     @Test
     void shouldReturnEmptyPayloadForAnInvalidCellType() throws Exception {
-        this.mockMvc.perform(get("/json/cell-type-marker-genes/{cellType}", "fooBar")
-                .param("experimentAccession", "E-CURD-4"))
+        this.mockMvc.perform(get("/json/cell-type-marker-genes/{cellType}", getEncodedCellType("fooBar"))
+                        .param("experimentAccession", "E-CURD-4"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8))
                 .andExpect(jsonPath("$", is(empty())));
+    }
+
+    private static String getEncodedCellType(String cellType) {
+        byte[] CellType = cellType.getBytes(StandardCharsets.UTF_8);
+        final String encodedCellType = Base64.getEncoder().encodeToString(CellType);
+        return encodedCellType;
     }
 }

--- a/app/src/test/java/uk/ac/ebi/atlas/search/metadata/JsonMultiexperimentCellTypeMarkerGenesControllerWIT.java
+++ b/app/src/test/java/uk/ac/ebi/atlas/search/metadata/JsonMultiexperimentCellTypeMarkerGenesControllerWIT.java
@@ -95,10 +95,6 @@ class JsonMultiexperimentCellTypeMarkerGenesControllerWIT {
     }
 
     private static String getEncodedCellType(String cellType) {
-        if (cellType == null) {
-            throw new IllegalArgumentException("cellType cannot be null");
-        }
-
         return Base64.getEncoder().encodeToString(cellType.getBytes(StandardCharsets.UTF_8));
     }
 }

--- a/app/src/test/java/uk/ac/ebi/atlas/search/metadata/JsonMultiexperimentCellTypeMarkerGenesControllerWIT.java
+++ b/app/src/test/java/uk/ac/ebi/atlas/search/metadata/JsonMultiexperimentCellTypeMarkerGenesControllerWIT.java
@@ -63,7 +63,8 @@ class JsonMultiexperimentCellTypeMarkerGenesControllerWIT {
 
     @Test
     void shouldReturnAValidJsonPayloadForAValidCellType() throws Exception {
-        this.mockMvc.perform(get("/json/cell-type-marker-genes/{cellType}", getEncodedCellType("cell cycle S phase"))
+        this.mockMvc.perform(get("/json/cell-type-marker-genes/{cellType}",
+                        getEncodedCellType("cell cycle S phase"))
                         .param("experimentAccession", "E-ENAD-53"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8))
@@ -75,7 +76,8 @@ class JsonMultiexperimentCellTypeMarkerGenesControllerWIT {
 
     @Test
     void shouldReturnAValidJsonPayloadForACellTypeContainingAForwardSlash() throws Exception {
-        this.mockMvc.perform(get("/json/cell-type-marker-genes/{cellType}", getEncodedCellType("cell cycle G2/M phase"))
+        this.mockMvc.perform(get("/json/cell-type-marker-genes/{cellType}",
+                        getEncodedCellType("cell cycle G2/M phase"))
                         .param("experimentAccession", "E-ENAD-53"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8))
@@ -87,7 +89,8 @@ class JsonMultiexperimentCellTypeMarkerGenesControllerWIT {
 
     @Test
     void shouldReturnEmptyPayloadForAnInvalidCellType() throws Exception {
-        this.mockMvc.perform(get("/json/cell-type-marker-genes/{cellType}", getEncodedCellType("fooBar"))
+        this.mockMvc.perform(get("/json/cell-type-marker-genes/{cellType}",
+                        getEncodedCellType("fooBar"))
                         .param("experimentAccession", "E-CURD-4"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8))

--- a/app/src/test/java/uk/ac/ebi/atlas/search/metadata/JsonMultiexperimentCellTypeMarkerGenesControllerWIT.java
+++ b/app/src/test/java/uk/ac/ebi/atlas/search/metadata/JsonMultiexperimentCellTypeMarkerGenesControllerWIT.java
@@ -95,8 +95,11 @@ class JsonMultiexperimentCellTypeMarkerGenesControllerWIT {
     }
 
     private static String getEncodedCellType(String cellType) {
-        byte[] CellType = cellType.getBytes(StandardCharsets.UTF_8);
-        final String encodedCellType = Base64.getEncoder().encodeToString(CellType);
-        return encodedCellType;
+        if (cellType == null) {
+            throw new IllegalArgumentException("cellType cannot be null");
+        }
+
+        byte[] cellTypeBytes = cellType.getBytes(StandardCharsets.UTF_8);
+        return Base64.getEncoder().encodeToString(cellTypeBytes);
     }
 }

--- a/app/src/test/java/uk/ac/ebi/atlas/search/metadata/JsonMultiexperimentCellTypeMarkerGenesControllerWIT.java
+++ b/app/src/test/java/uk/ac/ebi/atlas/search/metadata/JsonMultiexperimentCellTypeMarkerGenesControllerWIT.java
@@ -99,7 +99,6 @@ class JsonMultiexperimentCellTypeMarkerGenesControllerWIT {
             throw new IllegalArgumentException("cellType cannot be null");
         }
 
-        byte[] cellTypeBytes = cellType.getBytes(StandardCharsets.UTF_8);
-        return Base64.getEncoder().encodeToString(cellTypeBytes);
+        return Base64.getEncoder().encodeToString(cellType.getBytes(StandardCharsets.UTF_8));
     }
 }


### PR DESCRIPTION
Add Base64 decoder to decode cell type which is received by the frontend

In the frontend celltypewheel when we clicked on cell type with / value, the backend did not accept that URI, so we added encodeURIComponent(btoa) functions at the frontend to do Base64 encode of cell type as part of URI to accept '/' by the tomcat and API endpoint(/json/cell-type-marker-genes/{cellType})