### PR TITLE
Fix eslint version mismatch

### DIFF
--- a/app/src/main/javascript/bundles/cell-type-wheel-heatmap/package.json
+++ b/app/src/main/javascript/bundles/cell-type-wheel-heatmap/package.json
@@ -16,9 +16,5 @@
     "@ebi-gene-expression-group/scxa-cell-type-wheel-heatmap": "^1.4.14",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
-  },
-  "devDependencies": {
-    "@ebi-gene-expression-group/eslint-config": "^3.5.1",
-    "eslint": "^8.17.0"
   }
 }

--- a/compile-front-end-packages.sh
+++ b/compile-front-end-packages.sh
@@ -66,7 +66,6 @@ for MODULE_DIR in `ls`
 do
   pushd .
   cd $MODULE_DIR
-  update_npm_package
   echo ">> $PWD$ npm run prepare"
   npm run prepare
   popd


### PR DESCRIPTION
 @ebi-gene-expression-group/eslint-config versions caused errors while building npm packages in modules and cell-type-wheel-heatmap bundle, so we need to fix the package.json and building webpack bundles command to make sure we do not install nor update any old packages without keeping updating the root packages.