### PR TITLE
Refactor experiment's external resource handling

### DIFF
--- a/buildSrc/src/main/groovy/atlas-web-app.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/atlas-web-app.java-conventions.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = 'uk.ac.ebi.ge'
-version = '16.0.0'
+version = '16.0.2'
 
 sourceCompatibility = 11
 targetCompatibility = 11


### PR DESCRIPTION
This is a complete refactor of experiment's external resource handling.

- There was an error regarding to EGA resource links. Every link's URI contained /studies even if that resource was a dataset.
- Also some archive's base resource link has been updated.

Accompanying PR in web-core: https://github.com/ebi-gene-expression-group/atlas-web-core/pull/148