### PR TITLE
Set HttpOnly argument for cookies true in the HTTP request headers

### DIFF
--- a/app/src/main/java/uk/ac/ebi/atlas/configuration/HttpOnlyCookieConfigurator.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/configuration/HttpOnlyCookieConfigurator.java
@@ -1,0 +1,19 @@
+package uk.ac.ebi.atlas.configuration;
+
+import javax.servlet.ServletContext;
+import javax.servlet.ServletContextEvent;
+import javax.servlet.ServletContextListener;
+
+public class HttpOnlyCookieConfigurator implements ServletContextListener {
+    @Override
+    public void contextInitialized(ServletContextEvent event) {
+        ServletContext servletContext = event.getServletContext();
+        var cookieConfig = servletContext.getSessionCookieConfig();
+        cookieConfig.setHttpOnly(true);
+    }
+
+    @Override
+    public void contextDestroyed(ServletContextEvent servletContextEvent) {
+        // No need to do anything here, as the config for cookies is set for the lifetime of the application
+    }
+}

--- a/app/src/main/webapp/META-INF/context.xml
+++ b/app/src/main/webapp/META-INF/context.xml
@@ -2,6 +2,7 @@
 <!-- In production environments set deployXML="false" in the relevant <Host> section in server.xml, and add gxa#sc.xml
      to e.g. $CATALINA_BASE/conf/Catalina/localhost to configure the location of properties files -->
 <Context>
+    <CookieProcessor useHttpOnly="true"/>
     <Resources className="org.apache.catalina.webresources.StandardRoot">
         <PreResources className="org.apache.catalina.webresources.DirResourceSet"
                       base="/webapp-properties"

--- a/app/src/main/webapp/WEB-INF/web.xml
+++ b/app/src/main/webapp/WEB-INF/web.xml
@@ -30,6 +30,10 @@
     </servlet-mapping>
 
     <listener>
+        <listener-class>uk.ac.ebi.atlas.configuration.HttpOnlyCookieConfigurator</listener-class>
+    </listener>
+
+    <listener>
         <listener-class>org.springframework.web.context.ContextLoaderListener</listener-class>
     </listener>
 
@@ -76,6 +80,9 @@
 
     <!-- Disable JSessionID -->
     <session-config>
+        <cookie-config>
+            <http-only>true</http-only>
+        </cookie-config>
         <tracking-mode>COOKIE</tracking-mode>
     </session-config>
 

--- a/app/src/main/webapp/WEB-INF/web.xml
+++ b/app/src/main/webapp/WEB-INF/web.xml
@@ -59,6 +59,20 @@
         <url-pattern>/json/*</url-pattern>
     </filter-mapping>
 
+    <filter>
+        <filter-name>httpHeaderSecurity</filter-name>
+        <filter-class>org.apache.catalina.filters.HttpHeaderSecurityFilter</filter-class>
+        <async-supported>true</async-supported>
+        <init-param>
+            <param-name>hstsEnabled</param-name>
+            <param-value>true</param-value>
+        </init-param>
+    </filter>
+    <filter-mapping>
+        <filter-name>httpHeaderSecurity</filter-name>
+        <url-pattern>/*</url-pattern>
+    </filter-mapping>
+
     <security-role>
         <role-name>admin</role-name>
     </security-role>

--- a/buildSrc/src/main/groovy/atlas-web-app.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/atlas-web-app.java-conventions.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = 'uk.ac.ebi.ge'
-version = '16.0.2'
+version = '16.1.0'
 
 sourceCompatibility = 11
 targetCompatibility = 11


### PR DESCRIPTION
With this change we increase the security of the cookies by set the HttpOnly parameters of the cookies to true.
We set it in 3 different ways in the backend:

- in the web.xml file
- in the context.xml file
- create a new listener that set this argument (HttpOnly) to true.

We are going to do some changes in the frontend in another PR.