### PR TITLE
Update download.jsp - replace Louvain with Leiden clustering 

### DIFF
--- a/app/src/main/webapp/WEB-INF/jsp/tiles/views/download.jsp
+++ b/app/src/main/webapp/WEB-INF/jsp/tiles/views/download.jsp
@@ -35,7 +35,7 @@
     <ul style="list-style-type: none">
       <li>
         <span class="icon icon-fileformats icon-TSV"/>
-        Clustering file: Results of unsupervised louvain clustering at a range of resolution values.
+        Clustering file: Results of unsupervised leiden clustering at a range of resolution values.
       </li>
       <li>
         <span class="icon icon-fileformats icon-TSV"/>


### PR DESCRIPTION
To be merged once this is in implemented widely in production (e.g. after an Ensembl reference update).