### PR TITLE
[Chore] #517 - Transform experiments list page

### DIFF
--- a/app/src/main/java/uk/ac/ebi/atlas/experiments/ExperimentsController.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/experiments/ExperimentsController.java
@@ -10,6 +10,8 @@ public class ExperimentsController extends HtmlExceptionHandlingController {
     @GetMapping(value = "/experiments", produces = "text/html;charset=UTF-8")
     public String
     getExperimentsListParameters(Model model) {
+        model.addAttribute("title", "Experiments");
+
         return "experiments";
     }
 }

--- a/app/src/main/resources/templates/thymeleaf/fragments/fragments.html
+++ b/app/src/main/resources/templates/thymeleaf/fragments/fragments.html
@@ -48,7 +48,7 @@
                         <li id="local-nav-experiments"><a th:href="@{/experiments}"><i class="icon icon-functional padding-right-medium" data-icon="C"></i>Browse experiments</a></li>
                         <li id="local-nav-download"><a th:href="@{/download}"><i class="icon icon-functional padding-right-medium" data-icon="="></i>Download</a></li>
                         <li id="local-nav-release-notes"><a th:href="@{/release-notes.html}"><i class="icon icon-generic padding-right-medium" data-icon=";"></i>Release notes</a></li>
-                        <li id="local-nav-help"><a th:href="@{/help.html?section=${section}}"><i class="icon icon-generic padding-right-medium" data-icon="?"></i>Help</a></li>
+                        <li id="local-nav-help"><a th:href="@{'/help.html?section=' + ${section}}"><i class="icon icon-generic padding-right-medium" data-icon="?"></i>Help</a></li>
                         <li id="local-nav-feedback"><a href="https://www.ebi.ac.uk/support/gxasc" target="_blank" data-icon="X"><i class="icon icon-generic padding-right-medium" data-icon="s"></i>Support</a></li>
                     </ul>
                 </nav>

--- a/app/src/main/resources/templates/thymeleaf/views/experiments.html
+++ b/app/src/main/resources/templates/thymeleaf/views/experiments.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<html th:replace="~{fragments/base :: base('views/experiments/experiments_content') }"
+      xmlns:th="http://www.thymeleaf.org" lang="en">
+</html>

--- a/app/src/main/resources/templates/thymeleaf/views/experiments/experiments_content.html
+++ b/app/src/main/resources/templates/thymeleaf/views/experiments/experiments_content.html
@@ -1,14 +1,13 @@
-<%@ page contentType="text/html;charset=UTF-8" %>
-
 <div id="experiments"></div>
 <div id="popup-placeholder"></div>
 <link rel="stylesheet" href="https://ebi.emblstatic.net/web_guidelines/EBI-Icon-fonts/v1.3/fonts.css" type="text/css"
       media="all"/>
 
-<script defer src="${pageContext.request.contextPath}/resources/js-bundles/experimentTable.bundle.js"></script>
+<script defer th:src="@{/resources/js-bundles/experimentTable.bundle.js}"></script>
 
-<script>
-    document.addEventListener('DOMContentLoaded', function (event) {
+<script th:inline="javascript" th:with="contextPath=@{/}">
+    const contextPath = /*[[${contextPath}]]*/ '';
+    document.addEventListener('DOMContentLoaded', function () {
         experimentTable.renderRouter(
             {
                 tableHeaders: [
@@ -94,9 +93,9 @@
                 },
                 sortColumnIndex: 0,
                 ascendingOrder: false,
-                host: '${pageContext.request.contextPath}/',
+                host: contextPath,
                 resource: 'json/experiments',
-                basename: '${pageContext.request.contextPath}'
+                basename: contextPath
             },
             'experiments');
     });

--- a/app/src/main/resources/templates/thymeleaf/views/home/search.html
+++ b/app/src/main/resources/templates/thymeleaf/views/home/search.html
@@ -9,10 +9,11 @@
 </div>
 
 <script defer th:src="@{/resources/js-bundles/geneSearchForm.bundle.js}"></script>
-<script th:with="contextPath=@{/}">
+<script th:inline="javascript" th:with="contextPath=@{/}">
+    const contextPath = /*[[${contextPath}]]*/ '';
     document.addEventListener("DOMContentLoaded", function () {
         geneSearchForm.render({
-            host: '$contextPath',
+            host: contextPath,
             resource: 'json/suggestions/species',
             defaultSpecies: ``,
             wrapperClassName: 'row expanded',
@@ -28,35 +29,35 @@
             searchExamples: [
                 {
                     text: 'CFTR (gene symbol)',
-                    url: '$contextPath/search?symbol=CFTR'
+                    url: contextPath + 'search?symbol=CFTR'
                 },
                 {
                     text: 'ENSG00000125798 (Ensembl ID)',
-                    url: '$contextPath/search?ensgene=ENSG00000125798'
+                    url: contextPath + 'search?ensgene=ENSG00000125798'
                 },
                 {
                     text: '657 (Entrez ID)',
-                    url: '$contextPath/search?entrezgene=657'
+                    url: contextPath + 'search?entrezgene=657'
                 },
                 {
                     text: 'MGI:98354 (MGI ID)',
-                    url: '$contextPath/search?mgi_id=MGI:98354'
+                    url: contextPath + 'search?mgi_id=MGI:98354'
                 },
                 {
                     text: 'FBgn0003062 (FlyBase ID)',
-                    url: '$contextPath/search?flybase_gene_id=FBgn0003062'
+                    url: contextPath + 'search?flybase_gene_id=FBgn0003062'
                 },
                 {
                     text: 'keratinocyte (cell type)',
-                    url: '$contextPath/search/metadata/keratinocyte'
+                    url: contextPath + 'search/metadata/keratinocyte'
                 },
                 {
                     text: 'liver (organ/organism part)',
-                    url: '$contextPath/search/metadata/liver'
+                    url: contextPath + 'search/metadata/liver'
                 },
                 {
                     text: 'lung cancer (disease/condition)',
-                    url: '$contextPath/search/metadata/lung cancer'
+                    url: contextPath + 'search/metadata/lung cancer'
                 }
             ]
         }, 'search-form')

--- a/app/src/main/webapp/WEB-INF/tiles/views.xml
+++ b/app/src/main/webapp/WEB-INF/tiles/views.xml
@@ -4,11 +4,6 @@
         "http://tiles.apache.org/dtds/tiles-config_3_0.dtd">
 
 <tiles-definitions>
-    <definition name="experiments" extends="base">
-        <put-attribute name="title" value="Experiments &lt; "/>
-        <put-attribute name="content" value="/WEB-INF/jsp/tiles/views/experiments.jsp"/>
-    </definition>
-
     <definition name="gene-search-results" extends="base">
         <put-attribute name="title" value="Search results &lt; "/>
         <put-attribute name="content" value="/WEB-INF/jsp/tiles/views/gene-search-results.jsp"/>


### PR DESCRIPTION
Changes:
- Replace JSP with Thymeleaf templates for experiments view
- Fixes:
  - Update Thymeleaf syntax for Help link generation
  - Use inlined contextPath variable to fix the links of the search examples