### PR TITLE
E-ANND experiment download files missing

### DIFF
--- a/app/src/main/java/uk/ac/ebi/atlas/experimentpage/tabs/ExperimentPageContentService.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/experimentpage/tabs/ExperimentPageContentService.java
@@ -77,6 +77,10 @@ public class ExperimentPageContentService {
                 .anyMatch(type -> type.toLowerCase().startsWith(EXPERIMENT_TECHNOLOGY_TYPE_PREFIX));
     }
 
+    private static boolean isAnndataExperiment(String experimentAccession) {
+        return experimentAccession.startsWith("E-ANND-");
+    }
+
     public JsonObject getTsnePlotData(String experimentAccession) {
         var result = new JsonObject();
         result.add(
@@ -128,7 +132,7 @@ public class ExperimentPageContentService {
                         ExperimentFileType.EXPERIMENT_DESIGN);
         List<ExperimentFileType> resultFiles = new ArrayList<>();
 
-        if (experimentAccession.startsWith("E-ANND-")) {
+        if (isAnndataExperiment(experimentAccession)) {
             // Mandatory files
             resultFiles.add(ExperimentFileType.MARKER_GENES);
             resultFiles.add(ExperimentFileType.NORMALISED);

--- a/app/src/main/java/uk/ac/ebi/atlas/experimentpage/tabs/ExperimentPageContentService.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/experimentpage/tabs/ExperimentPageContentService.java
@@ -81,6 +81,11 @@ public class ExperimentPageContentService {
         return experimentAccession.startsWith("E-ANND-");
     }
 
+    private boolean hasClusterTsvFileAndKs(String experimentAccession) {
+        return dataFileHub.getSingleCellExperimentFiles(experimentAccession).getClustersTsv().exists() &&
+                tsnePlotSettingsService.getAvailableKs(experimentAccession).size() > 0;
+    }
+
     public JsonObject getTsnePlotData(String experimentAccession) {
         var result = new JsonObject();
         result.add(
@@ -137,8 +142,7 @@ public class ExperimentPageContentService {
             resultFiles.add(ExperimentFileType.MARKER_GENES);
             resultFiles.add(ExperimentFileType.NORMALISED);
             // Optional CLUSTERING
-            if (dataFileHub.getSingleCellExperimentFiles(experimentAccession).getClustersTsv().exists() &&
-                    tsnePlotSettingsService.getAvailableKs(experimentAccession).size() > 0)
+            if (hasClusterTsvFileAndKs(experimentAccession))
             {
                 resultFiles.add(ExperimentFileType.CLUSTERING);
             }

--- a/app/src/main/java/uk/ac/ebi/atlas/experimentpage/tabs/ExperimentPageContentService.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/experimentpage/tabs/ExperimentPageContentService.java
@@ -132,9 +132,8 @@ public class ExperimentPageContentService {
             // Mandatory files
             resultFiles.add(ExperimentFileType.MARKER_GENES);
             resultFiles.add(ExperimentFileType.NORMALISED);
-            var clusterFilePath = experimentFileLocationService.getFilePath(experimentAccession, ExperimentFileType.CLUSTERING);
             // Optional CLUSTERING
-            if (clusterFilePath != null) {
+            if (dataFileHub.getSingleCellExperimentFiles(experimentAccession).getClustersTsv().exists()) {
                 resultFiles.add(ExperimentFileType.CLUSTERING);
             }
         } else {

--- a/app/src/main/java/uk/ac/ebi/atlas/experimentpage/tabs/ExperimentPageContentService.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/experimentpage/tabs/ExperimentPageContentService.java
@@ -24,6 +24,7 @@ import uk.ac.ebi.atlas.search.OntologyAccessionsSearchService;
 import uk.ac.ebi.atlas.trader.ExperimentTrader;
 import uk.ac.ebi.atlas.utils.StringUtil;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -125,19 +126,27 @@ public class ExperimentPageContentService {
                 ImmutableList.of(
                         ExperimentFileType.EXPERIMENT_METADATA,
                         ExperimentFileType.EXPERIMENT_DESIGN);
+        List<ExperimentFileType> resultFiles = new ArrayList<>();
 
-        var resultFiles = isSmartExperiment(technologyType) ?
-                ImmutableList.of(
-                        ExperimentFileType.CLUSTERING,
-                        ExperimentFileType.QUANTIFICATION_FILTERED,
-                        ExperimentFileType.MARKER_GENES,
-                        ExperimentFileType.NORMALISED,
-                        ExperimentFileType.QUANTIFICATION_RAW) :
-                ImmutableList.of(
-                        ExperimentFileType.CLUSTERING,
-                        ExperimentFileType.MARKER_GENES,
-                        ExperimentFileType.NORMALISED,
-                        ExperimentFileType.QUANTIFICATION_RAW);
+        if (experimentAccession.startsWith("E-ANND-")) {
+            // Mandatory files
+            resultFiles.add(ExperimentFileType.MARKER_GENES);
+            resultFiles.add(ExperimentFileType.NORMALISED);
+            var clusterFilePath = experimentFileLocationService.getFilePath(experimentAccession, ExperimentFileType.CLUSTERING);
+            // Optional CLUSTERING
+            if (clusterFilePath != null) {
+                resultFiles.add(ExperimentFileType.CLUSTERING);
+            }
+        } else {
+            resultFiles.add(ExperimentFileType.CLUSTERING);
+            resultFiles.add(ExperimentFileType.MARKER_GENES);
+            resultFiles.add(ExperimentFileType.NORMALISED);
+            resultFiles.add(ExperimentFileType.QUANTIFICATION_RAW);
+
+            if (isSmartExperiment(technologyType)) {
+                resultFiles.add(ExperimentFileType.QUANTIFICATION_FILTERED);
+            }
+        }
 
         result.add(getDownloadSection("Metadata files", metadataFiles, experimentAccession, accessKey));
         result.add(getDownloadSection("Result files", resultFiles, experimentAccession, accessKey));

--- a/app/src/main/java/uk/ac/ebi/atlas/experimentpage/tabs/ExperimentPageContentService.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/experimentpage/tabs/ExperimentPageContentService.java
@@ -133,7 +133,9 @@ public class ExperimentPageContentService {
             resultFiles.add(ExperimentFileType.MARKER_GENES);
             resultFiles.add(ExperimentFileType.NORMALISED);
             // Optional CLUSTERING
-            if (dataFileHub.getSingleCellExperimentFiles(experimentAccession).getClustersTsv().exists()) {
+            if (dataFileHub.getSingleCellExperimentFiles(experimentAccession).getClustersTsv().exists() &&
+                    tsnePlotSettingsService.getAvailableKs(experimentAccession).size() > 0)
+            {
                 resultFiles.add(ExperimentFileType.CLUSTERING);
             }
         } else {

--- a/app/src/main/java/uk/ac/ebi/atlas/experimentpage/tabs/ExperimentPageContentService.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/experimentpage/tabs/ExperimentPageContentService.java
@@ -83,7 +83,7 @@ public class ExperimentPageContentService {
 
     private boolean hasClusterTsvFileAndKs(String experimentAccession) {
         return dataFileHub.getSingleCellExperimentFiles(experimentAccession).getClustersTsv().exists() &&
-                tsnePlotSettingsService.getAvailableKs(experimentAccession).size() > 0;
+                !tsnePlotSettingsService.getAvailableKs(experimentAccession).isEmpty();
     }
 
     public JsonObject getTsnePlotData(String experimentAccession) {

--- a/app/src/main/java/uk/ac/ebi/atlas/experimentpage/tsneplot/TSnePlotSettingsService.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/experimentpage/tsneplot/TSnePlotSettingsService.java
@@ -8,6 +8,7 @@ import uk.ac.ebi.atlas.experimentimport.idf.IdfParser;
 import uk.ac.ebi.atlas.experimentimport.idf.IdfParserOutput;
 import uk.ac.ebi.atlas.experimentpage.markergenes.MarkerGenesDao;
 import uk.ac.ebi.atlas.resource.DataFileHub;
+import uk.ac.ebi.atlas.model.resource.AtlasResource;
 
 import java.util.List;
 import java.util.Map;
@@ -32,7 +33,7 @@ public class TSnePlotSettingsService {
     }
 
     public List<Integer> getAvailableKs(String experimentAccession) {
-        var clustersTsv = dataFileHub.getSingleCellExperimentFiles(experimentAccession).clustersTsv;
+        var clustersTsv = getClusterTsvFile(experimentAccession);
 
         if (!clustersTsv.exists()) {
             return List.of();
@@ -54,10 +55,14 @@ public class TSnePlotSettingsService {
         return tSnePlotDao.fetchPerplexities(experimentAccession);
     }
 
+    private AtlasResource<TsvStreamer> getClusterTsvFile(String experimentAccession) {
+        return dataFileHub.getSingleCellExperimentFiles(experimentAccession).clustersTsv;
+    }
+
     @Cacheable("expectedClusters")
     public Optional<Integer> getExpectedClusters(String experimentAccession) {
         IdfParserOutput idfParserOutput = idfParser.parse(experimentAccession);
-        var clustersTsv = dataFileHub.getSingleCellExperimentFiles(experimentAccession).clustersTsv;
+        var clustersTsv = getClusterTsvFile(experimentAccession);
 
         // Check if expectedClusters is valid and among available Ks
         int expectedClusters = idfParserOutput.getExpectedClusters();

--- a/app/src/main/java/uk/ac/ebi/atlas/experimentpage/tsneplot/TSnePlotSettingsService.java
+++ b/app/src/main/java/uk/ac/ebi/atlas/experimentpage/tsneplot/TSnePlotSettingsService.java
@@ -32,10 +32,15 @@ public class TSnePlotSettingsService {
     }
 
     public List<Integer> getAvailableKs(String experimentAccession) {
-        try (TsvStreamer clustersTsvStreamer =
-                     dataFileHub.getSingleCellExperimentFiles(experimentAccession).clustersTsv.get()) {
+        var clustersTsv = dataFileHub.getSingleCellExperimentFiles(experimentAccession).clustersTsv;
+
+        if (!clustersTsv.exists()) {
+            return List.of();
+        }
+
+        try (TsvStreamer clustersTsvStreamer = clustersTsv.get()) {
             return clustersTsvStreamer.get()
-                    .skip(1)
+                    .skip(1)  // skip header
                     .map(line -> Integer.parseInt(line[1]))
                     .collect(Collectors.toList());
         }
@@ -52,20 +57,25 @@ public class TSnePlotSettingsService {
     @Cacheable("expectedClusters")
     public Optional<Integer> getExpectedClusters(String experimentAccession) {
         IdfParserOutput idfParserOutput = idfParser.parse(experimentAccession);
+        var clustersTsv = dataFileHub.getSingleCellExperimentFiles(experimentAccession).clustersTsv;
 
-        // Only add preferred cluster property if it exists in the idf file and it is one of the available k values
-        if (idfParserOutput.getExpectedClusters() != 0 &&
-                getAvailableKs(experimentAccession).contains(idfParserOutput.getExpectedClusters())) {
-            return Optional.of(idfParserOutput.getExpectedClusters());
-        } else {
-            try (TsvStreamer clustersTsvStreamer =
-                         dataFileHub.getSingleCellExperimentFiles(experimentAccession).clustersTsv.get()) {
-                return clustersTsvStreamer.get()
-                        .skip(1)
-                        .filter(line -> line[0].equalsIgnoreCase("true"))
-                        .map(line -> Integer.parseInt(line[1]))
-                        .findFirst();
-            }
+        // Check if expectedClusters is valid and among available Ks
+        int expectedClusters = idfParserOutput.getExpectedClusters();
+        if (expectedClusters != 0 && getAvailableKs(experimentAccession).contains(expectedClusters)) {
+            return Optional.of(expectedClusters);
+        }
+
+        // Return empty if file doesn't exist
+        if (!clustersTsv.exists()) {
+            return Optional.empty();
+        }
+
+        try (TsvStreamer clustersTsvStreamer = clustersTsv.get()) {
+            return clustersTsvStreamer.get()
+                    .skip(1)
+                    .filter(line -> line[0].equalsIgnoreCase("true"))
+                    .map(line -> Integer.parseInt(line[1]))
+                    .findFirst();
         }
     }
 

--- a/app/src/test/java/uk/ac/ebi/atlas/experimentpage/TSnePlotSettingsServiceIT.java
+++ b/app/src/test/java/uk/ac/ebi/atlas/experimentpage/TSnePlotSettingsServiceIT.java
@@ -104,9 +104,12 @@ class TSnePlotSettingsServiceIT {
                 .doesNotHaveDuplicates();
     }
 
+    //Anndata experiments may not have Ks, we not throw errors for this, but return empty list instead
     @Test()
     void getClustersForInvalidAccessionThrowsException() {
-        assertThatExceptionOfType(UncheckedIOException.class).isThrownBy(() -> subject.getAvailableKs("FOO"));
+        List<Integer> result = subject.getAvailableKs(jdbcTestUtils.fetchRandomExperimentAccession());
+
+        assertThat(result).isEmpty();
     }
 
     @Test

--- a/app/src/test/java/uk/ac/ebi/atlas/experimentpage/TSnePlotSettingsServiceIT.java
+++ b/app/src/test/java/uk/ac/ebi/atlas/experimentpage/TSnePlotSettingsServiceIT.java
@@ -107,7 +107,7 @@ class TSnePlotSettingsServiceIT {
     //Anndata experiments may not have Ks, we not throw errors for this, but return empty list instead
     @Test()
     void getClustersForInvalidAccessionThrowsException() {
-        List<Integer> result = subject.getAvailableKs(jdbcTestUtils.fetchRandomExperimentAccession());
+        List<Integer> result = subject.getAvailableKs("FOO");
 
         assertThat(result).isEmpty();
     }

--- a/app/src/test/java/uk/ac/ebi/atlas/experimentpage/tabs/ExperimentPageContentServiceTest.java
+++ b/app/src/test/java/uk/ac/ebi/atlas/experimentpage/tabs/ExperimentPageContentServiceTest.java
@@ -140,6 +140,29 @@ class ExperimentPageContentServiceTest {
         tpmsDownloadJsonObject.addProperty("isDownload", true);
     }
 
+    private void setupCommonExperimentMocks(String experimentAccession) {
+        for (var type : ImmutableList.of(
+                ExperimentFileType.EXPERIMENT_METADATA,
+                ExperimentFileType.EXPERIMENT_DESIGN,
+                ExperimentFileType.CLUSTERING,
+                ExperimentFileType.MARKER_GENES,
+                ExperimentFileType.NORMALISED
+        )) {
+            when(experimentFileLocationServiceMock.getFileUri(experimentAccession, type, ""))
+                    .thenReturn(URI.create(EXPERIMENT_FILES_URI_TEMPLATE));
+        }
+    }
+
+    private void setupFileExistenceMock(String experimentAccession, boolean clusteringExists) {
+        var singleCellFilesMock = mock(SingleCellExperimentFiles.class);
+        var clustersTsvMock = mock(AtlasResource.class);
+
+        when(dataFileHubMock.getSingleCellExperimentFiles(experimentAccession))
+                .thenReturn(singleCellFilesMock);
+        when(singleCellFilesMock.getClustersTsv()).thenReturn(clustersTsvMock);
+        when(clustersTsvMock.exists()).thenReturn(clusteringExists);
+    }
+
     @Test
     void testGetDownloadsForANNDExperiment_withClustering() {
         var experimentAccession = "E-ANND-123";
@@ -149,45 +172,8 @@ class ExperimentPageContentServiceTest {
                 .build();
         when(experimentTraderMock.getExperiment(experimentAccession, "")).thenReturn(experiment);
 
-        when(experimentFileLocationServiceMock.getFileUri(
-                experimentAccession,
-                ExperimentFileType.EXPERIMENT_METADATA,
-                "")
-        ).thenReturn(URI.create(EXPERIMENT_FILES_ARCHIVE_URI_TEMPLATE));
-
-        when(experimentFileLocationServiceMock.getFileUri(
-                experimentAccession,
-                ExperimentFileType.EXPERIMENT_DESIGN,
-                "")
-        ).thenReturn(URI.create(EXPERIMENT_FILES_URI_TEMPLATE));
-
-        when(experimentFileLocationServiceMock.getFileUri(
-                experimentAccession,
-                ExperimentFileType.CLUSTERING,
-                "")
-        ).thenReturn(URI.create(EXPERIMENT_FILES_URI_TEMPLATE));
-        when(experimentFileLocationServiceMock.getFileUri(
-                experimentAccession,
-                ExperimentFileType.MARKER_GENES,
-                "")
-        ).thenReturn(URI.create(EXPERIMENT_FILES_ARCHIVE_URI_TEMPLATE));
-
-        when(experimentFileLocationServiceMock.getFileUri(
-                experimentAccession,
-                ExperimentFileType.NORMALISED,
-                "")
-        ).thenReturn(URI.create(EXPERIMENT_FILES_ARCHIVE_URI_TEMPLATE));
-
-        SingleCellExperimentFiles singleCellExperimentFilesMock = mock(SingleCellExperimentFiles.class);
-
-        AtlasResource<TsvStreamer> clustersTsvMock = mock(AtlasResource.class);
-
-        when(dataFileHubMock.getSingleCellExperimentFiles(experimentAccession))
-                .thenReturn(singleCellExperimentFilesMock);
-        when(singleCellExperimentFilesMock.getClustersTsv())
-                .thenReturn(clustersTsvMock);
-        when(clustersTsvMock.exists())
-                .thenReturn(true);
+        setupCommonExperimentMocks(experimentAccession);
+        setupFileExistenceMock(experimentAccession, true);
 
         var downloads = subject.getDownloads(experimentAccession, "");
 
@@ -212,45 +198,8 @@ class ExperimentPageContentServiceTest {
                 .build();
         when(experimentTraderMock.getExperiment(experimentAccession, "")).thenReturn(experiment);
 
-        when(experimentFileLocationServiceMock.getFileUri(
-                experimentAccession,
-                ExperimentFileType.EXPERIMENT_METADATA,
-                "")
-        ).thenReturn(URI.create(EXPERIMENT_FILES_ARCHIVE_URI_TEMPLATE));
-
-        when(experimentFileLocationServiceMock.getFileUri(
-                experimentAccession,
-                ExperimentFileType.EXPERIMENT_DESIGN,
-                "")
-        ).thenReturn(URI.create(EXPERIMENT_FILES_URI_TEMPLATE));
-
-        when(experimentFileLocationServiceMock.getFileUri(
-                experimentAccession,
-                ExperimentFileType.CLUSTERING,
-                "")
-        ).thenReturn(URI.create(EXPERIMENT_FILES_URI_TEMPLATE));
-        when(experimentFileLocationServiceMock.getFileUri(
-                experimentAccession,
-                ExperimentFileType.MARKER_GENES,
-                "")
-        ).thenReturn(URI.create(EXPERIMENT_FILES_ARCHIVE_URI_TEMPLATE));
-
-        when(experimentFileLocationServiceMock.getFileUri(
-                experimentAccession,
-                ExperimentFileType.NORMALISED,
-                "")
-        ).thenReturn(URI.create(EXPERIMENT_FILES_ARCHIVE_URI_TEMPLATE));
-
-        SingleCellExperimentFiles singleCellExperimentFilesMock = mock(SingleCellExperimentFiles.class);
-
-        AtlasResource<TsvStreamer> clustersTsvMock = mock(AtlasResource.class);
-
-        when(dataFileHubMock.getSingleCellExperimentFiles(experimentAccession))
-                .thenReturn(singleCellExperimentFilesMock);
-        when(singleCellExperimentFilesMock.getClustersTsv())
-                .thenReturn(clustersTsvMock);
-        when(clustersTsvMock.exists())
-                .thenReturn(false);
+        setupCommonExperimentMocks(experimentAccession);
+        setupFileExistenceMock(experimentAccession, false);
 
         var downloads = subject.getDownloads(experimentAccession, "");
 

--- a/app/src/test/java/uk/ac/ebi/atlas/experimentpage/tabs/ExperimentPageContentServiceTest.java
+++ b/app/src/test/java/uk/ac/ebi/atlas/experimentpage/tabs/ExperimentPageContentServiceTest.java
@@ -12,6 +12,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
+import uk.ac.ebi.atlas.commons.readers.TsvStreamer;
 import uk.ac.ebi.atlas.download.ExperimentFileLocationService;
 import uk.ac.ebi.atlas.download.ExperimentFileType;
 import uk.ac.ebi.atlas.download.IconType;
@@ -20,7 +21,9 @@ import uk.ac.ebi.atlas.experimentpage.markergenes.MarkerGeneService;
 import uk.ac.ebi.atlas.experimentpage.metadata.CellMetadataService;
 import uk.ac.ebi.atlas.experimentpage.tsneplot.TSnePlotSettingsService;
 import uk.ac.ebi.atlas.experiments.ExperimentBuilder;
+import uk.ac.ebi.atlas.model.resource.AtlasResource;
 import uk.ac.ebi.atlas.resource.DataFileHub;
+import uk.ac.ebi.atlas.resource.DataFileHub.SingleCellExperimentFiles;
 import uk.ac.ebi.atlas.search.OntologyAccessionsSearchService;
 import uk.ac.ebi.atlas.trader.ExperimentTrader;
 
@@ -32,6 +35,7 @@ import java.util.concurrent.ThreadLocalRandom;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.mock;
 import static uk.ac.ebi.atlas.testutils.RandomDataTestUtils.generateRandomExperimentAccession;
 
 @ExtendWith(MockitoExtension.class)
@@ -134,6 +138,132 @@ class ExperimentPageContentServiceTest {
         tpmsDownloadJsonObject.addProperty("type", IconType.TSV.getName());
         tpmsDownloadJsonObject.addProperty("description", "Filtered TPMs files (MatrixMarket archive)");
         tpmsDownloadJsonObject.addProperty("isDownload", true);
+    }
+
+    @Test
+    void testGetDownloadsForANNDExperiment_withClustering() {
+        var experimentAccession = "E-ANND-123";
+        var experiment = new ExperimentBuilder.SingleCellBaselineExperimentBuilder()
+                .withExperimentAccession(experimentAccession)
+                .withTechnologyType(ImmutableList.of("Smart-Seq", "10xV1"))
+                .build();
+        when(experimentTraderMock.getExperiment(experimentAccession, "")).thenReturn(experiment);
+
+        when(experimentFileLocationServiceMock.getFileUri(
+                experimentAccession,
+                ExperimentFileType.EXPERIMENT_METADATA,
+                "")
+        ).thenReturn(URI.create(EXPERIMENT_FILES_ARCHIVE_URI_TEMPLATE));
+
+        when(experimentFileLocationServiceMock.getFileUri(
+                experimentAccession,
+                ExperimentFileType.EXPERIMENT_DESIGN,
+                "")
+        ).thenReturn(URI.create(EXPERIMENT_FILES_URI_TEMPLATE));
+
+        when(experimentFileLocationServiceMock.getFileUri(
+                experimentAccession,
+                ExperimentFileType.CLUSTERING,
+                "")
+        ).thenReturn(URI.create(EXPERIMENT_FILES_URI_TEMPLATE));
+        when(experimentFileLocationServiceMock.getFileUri(
+                experimentAccession,
+                ExperimentFileType.MARKER_GENES,
+                "")
+        ).thenReturn(URI.create(EXPERIMENT_FILES_ARCHIVE_URI_TEMPLATE));
+
+        when(experimentFileLocationServiceMock.getFileUri(
+                experimentAccession,
+                ExperimentFileType.NORMALISED,
+                "")
+        ).thenReturn(URI.create(EXPERIMENT_FILES_ARCHIVE_URI_TEMPLATE));
+
+        SingleCellExperimentFiles singleCellExperimentFilesMock = mock(SingleCellExperimentFiles.class);
+
+        AtlasResource<TsvStreamer> clustersTsvMock = mock(AtlasResource.class);
+
+        when(dataFileHubMock.getSingleCellExperimentFiles(experimentAccession))
+                .thenReturn(singleCellExperimentFilesMock);
+        when(singleCellExperimentFilesMock.getClustersTsv())
+                .thenReturn(clustersTsvMock);
+        when(clustersTsvMock.exists())
+                .thenReturn(true);
+
+        var downloads = subject.getDownloads(experimentAccession, "");
+
+        assertThat(downloads)
+                .hasSize(2)
+                .filteredOn(jsonElement -> jsonElement.getAsJsonObject().get("title").getAsString().equalsIgnoreCase("Result Files"))
+                .hasSize(1)
+                .extracting(jsonElement -> jsonElement.getAsJsonObject().get("files").getAsJsonArray())
+                .hasSize(1)
+                .first()
+                .satisfies(jsonArray -> {
+                    assertThat(jsonArray).hasSize(3);
+                });
+    }
+
+    @Test
+    void testGetDownloadsForANNDExperiment_withoutClustering() {
+        var experimentAccession = "E-ANND-123";
+        var experiment = new ExperimentBuilder.SingleCellBaselineExperimentBuilder()
+                .withExperimentAccession(experimentAccession)
+                .withTechnologyType(ImmutableList.of("Smart-Seq", "10xV1"))
+                .build();
+        when(experimentTraderMock.getExperiment(experimentAccession, "")).thenReturn(experiment);
+
+        when(experimentFileLocationServiceMock.getFileUri(
+                experimentAccession,
+                ExperimentFileType.EXPERIMENT_METADATA,
+                "")
+        ).thenReturn(URI.create(EXPERIMENT_FILES_ARCHIVE_URI_TEMPLATE));
+
+        when(experimentFileLocationServiceMock.getFileUri(
+                experimentAccession,
+                ExperimentFileType.EXPERIMENT_DESIGN,
+                "")
+        ).thenReturn(URI.create(EXPERIMENT_FILES_URI_TEMPLATE));
+
+        when(experimentFileLocationServiceMock.getFileUri(
+                experimentAccession,
+                ExperimentFileType.CLUSTERING,
+                "")
+        ).thenReturn(URI.create(EXPERIMENT_FILES_URI_TEMPLATE));
+        when(experimentFileLocationServiceMock.getFileUri(
+                experimentAccession,
+                ExperimentFileType.MARKER_GENES,
+                "")
+        ).thenReturn(URI.create(EXPERIMENT_FILES_ARCHIVE_URI_TEMPLATE));
+
+        when(experimentFileLocationServiceMock.getFileUri(
+                experimentAccession,
+                ExperimentFileType.NORMALISED,
+                "")
+        ).thenReturn(URI.create(EXPERIMENT_FILES_ARCHIVE_URI_TEMPLATE));
+
+        SingleCellExperimentFiles singleCellExperimentFilesMock = mock(SingleCellExperimentFiles.class);
+
+        AtlasResource<TsvStreamer> clustersTsvMock = mock(AtlasResource.class);
+
+        when(dataFileHubMock.getSingleCellExperimentFiles(experimentAccession))
+                .thenReturn(singleCellExperimentFilesMock);
+        when(singleCellExperimentFilesMock.getClustersTsv())
+                .thenReturn(clustersTsvMock);
+        when(clustersTsvMock.exists())
+                .thenReturn(false);
+
+        var downloads = subject.getDownloads(experimentAccession, "");
+
+        assertThat(downloads)
+                .hasSize(2)
+                .filteredOn(jsonElement -> jsonElement.getAsJsonObject().get("title").getAsString().equalsIgnoreCase("Result Files"))
+                .hasSize(1)
+                .extracting(jsonElement -> jsonElement.getAsJsonObject().get("files").getAsJsonArray())
+                .hasSize(1)
+                .first()
+                .satisfies(jsonArray -> {
+                    assertThat(jsonArray).hasSize(2);
+                });
     }
 
     @Test


### PR DESCRIPTION
See issue #535, coming with atlas-web-core PR https://github.com/ebi-gene-expression-group/atlas-web-core/pull/160

Marker gene files and normalised counts files should always be listed. Clustering file is optional.

Case 1: Anndata has cluster.tsv file but it is empty (just headers) -> not listed in the download
https://www-test.ebi.ac.uk/gxa/sc/experiments/E-ANND-3/downloads

Case 2: Anndata has cluster.tsv file and it is not empty (has ks) -> listed in the download
https://www-test.ebi.ac.uk/gxa/sc/experiments/E-ANND-5/downloads

Case 3: Anndata has no cluster.tsv file -> not listed in the download and not breaking experiment result page
(currently we cannot test it on www-test environment, as all ANND eperiments have cluster.tsv files)
PS. You may test it locally by removing cluster.tsv file from docker volume, or we can remove those empty files from file system on test envrionment