### PR TITLE
Remove the outdated survey banner

### DIFF
--- a/app/src/main/resources/templates/thymeleaf/views/home/home_content.html
+++ b/app/src/main/resources/templates/thymeleaf/views/home/home_content.html
@@ -1,20 +1,3 @@
-<script type="text/javascript">
-    document.addEventListener("DOMContentLoaded", function(){
-        ebiInjectAnnouncements(
-            {
-                headline: 'We need your help!',
-                message: 'Has Expression Atlas saved you time or effort? Please take 15 minutes to fill in a survey and help EMBL-EBI make the case for why open data resources are critical to life science research. Survey link: <a href="https://www.surveymonkey.com/r/QGFMBH8?channel=[webpage] ">https://www.surveymonkey.com/r/QGFMBH8?channel=[webpage] </a>',
-                priority: 'warning'
-            }
-        );
-    })
-
-    // Add custom CSS for the announcement banner
-    const style = document.createElement('style');
-    style.textContent = '.notifications-js { max-width: 100vw; }';
-    document.head.appendChild(style);
-</script>
-
 <div class="row expanded">
     <div th:replace="~{views/home/release-stats}"></div>
 </div>

--- a/buildSrc/src/main/groovy/atlas-web-app.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/atlas-web-app.java-conventions.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = 'uk.ac.ebi.ge'
-version = '17.1.0'
+version = '17.1.1'
 
 sourceCompatibility = 11
 targetCompatibility = 11


### PR DESCRIPTION
Remove the outdated survey announcement script from the home page template to clean up unused content.
Bump the project version from 17.1.0 to 17.1.1.