### PR TITLE
[Chore/GXA-565] Update the homepage's publication section with citation details

### DIFF
--- a/app/src/main/resources/templates/thymeleaf/views/home/publications.html
+++ b/app/src/main/resources/templates/thymeleaf/views/home/publications.html
@@ -1,5 +1,27 @@
 <div id="publication-list" class="callout" data-equalizer-watch>
-    <h4>Publications </h4>
+    <h4>How to cite Expression Atlas</h4>
+    <h5>
+        If you’re using Expression Atlas in your research, please consider citing our most recent update in
+        <i>Nucleic Acids Research:</i>
+    </h5>
+
+    <a href="https://academic.oup.com/nar/advance-article/doi/10.1093/nar/gkaf1238/8376685" target="_blank">
+        <div class="media-object">
+            <div class="media-object-section middle">
+                <h3 class="icon icon-conceptual" data-icon="l"></h3>
+            </div>
+            <div class="media-object-section middle">
+                <p>
+                    <strong>Expression Atlas in 2026:</strong> enabling FAIR and open expression data through community collaboration and integration<br>
+                    <em>Nucleic Acids Research</em>, 10 December 2025.
+                </p>
+            </div>
+        </div>
+    </a>
+
+    <h5>
+        If you would like to reference specific historical updates or methodology, you can also cite:
+    </h5>
     <a href="https://doi.org/10.1093/nar/gkad1021" target="_blank">
         <div class="media-object">
             <div class="media-object-section middle">

--- a/buildSrc/src/main/groovy/atlas-web-app.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/atlas-web-app.java-conventions.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = 'uk.ac.ebi.ge'
-version = '17.2.0'
+version = '17.3.0'
 
 sourceCompatibility = 11
 targetCompatibility = 11


### PR DESCRIPTION
Revised the publications page to include updated citation details for Single Cell Expression Atlas, highlighting the latest 2026 paper. Additionally, incremented the application version to 17.3.0 in the build configuration.